### PR TITLE
v0.3.0: Type performance, transform narrowing, and error diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Breaking Changes
 
 - **`Exact` type simplified** — `Exact<Shape, Candidate>` now only checks excess properties at the top level. Deep recursive checking of nested objects/arrays has been removed. DynamoDB key schemas are flat, so this should not affect typical usage.
-- **`.key()` narrows attributes to transform parameter types** — when a spec item has a transform function, `.key()` now accepts the transform's parameter type (e.g. `Pick<Device, 'userId'>`) instead of the full entity. Callers passing full entities still work.
+- **`.key()` narrows attributes to transform parameter types** — when a spec item has a transform function, `.key()` now accepts the transform's parameter type (e.g. `Pick<Obj, 'id'>`) instead of the full entity. Callers passing full entities still work.
 - **Schema keys are `readonly`** — `TableEntry` computed key fields are now `readonly`. Code that mutates computed keys on entries will get type errors.
 - **Invalid schemas return `ErrorMessage<>` instead of `never`** — code checking `extends never` on schema output types may behave differently.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog
+
+## 0.3.0
+
+### Breaking Changes
+
+- **`Exact` type simplified** — `Exact<Shape, Candidate>` now only checks excess properties at the top level. Deep recursive checking of nested objects/arrays has been removed. DynamoDB key schemas are flat, so this should not affect typical usage.
+- **`.key()` narrows attributes to transform parameter types** — when a spec item has a transform function, `.key()` now accepts the transform's parameter type (e.g. `Pick<Device, 'userId'>`) instead of the full entity. Callers passing full entities still work.
+- **Schema keys are `readonly`** — `TableEntry` computed key fields are now `readonly`. Code that mutates computed keys on entries will get type errors.
+- **Invalid schemas return `ErrorMessage<>` instead of `never`** — code checking `extends never` on schema output types may behave differently.
+
+### Added
+
+- **`RotoriseError`** — custom error class for all runtime errors thrown by Rotorise, enabling `catch` filtering.
+- **`ErrorMessage<T>` type** — branded type for compile-time error messages in the IDE.
+- **`TransformOverride`** — type-level support for narrowing `.key()` attributes based on transform parameter types.
+- **Empty separator guard** — `tableEntry()({...}, '')` is now a type error via `ErrorMessage`, in addition to the existing runtime check.
+- **Performance attest baselines** — new `Rotorise.attest.test.ts` with instantiation count benchmarks.
+- **`files: ["dist"]`** in `package.json` — prevents source/test files from being published to npm.
+- **`treeshake: true`** in tsup config — enables tree-shaking for consumers.
+- **JSDoc** on `TableEntry`, `TableEntryDefinition`, and `tableEntry`.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Rotorise
 
-Supercharge your DynamoDB with DynamoDB Rotorise!
+Type-safe DynamoDB composite key management for TypeScript.
 
-DynamoDB offers incredible flexibility, but managing advanced patterns and techniques can be a challenge. [Rotorise](https://github.com/josher8a/Rotorise) simplifies complex operations by providing abstractions for key definitions, composite key constructors, partial composite keys, and advanced sort key usage in queries.  It integrates seamlessly with the [Brushless](https://github.com/josher8a/Brushless) for a frictionless and performant DynamoDB experience.
+DynamoDB offers incredible flexibility, but managing advanced patterns and techniques can be a challenge. Rotorise simplifies complex operations by providing abstractions for key definitions, composite key constructors, partial composite keys, and advanced sort key usage in queries. It integrates seamlessly with [Brushless](https://github.com/josher8a/Brushless) for a frictionless and performant DynamoDB experience.
 
 ## Installation
 
@@ -10,6 +10,190 @@ DynamoDB offers incredible flexibility, but managing advanced patterns and techn
 npm install rotorise
 ```
 
+## Quick Start
+
+Define your entity type and schema. Rotorise infers the exact key string types.
+
+```ts
+import { tableEntry } from 'rotorise'
+
+type User = {
+  orgId: string
+  id: string
+  role: 'admin' | 'user' | 'guest'
+  email: string
+}
+
+const UserTable = tableEntry<User>()({
+  PK: ['orgId', 'id'],
+  SK: ['role'],
+  GSI1PK: ['role'],
+  GSI1SK: 'email',
+})
+```
+
+## API
+
+### `tableEntry<Entity>()(schema, separator?)`
+
+Entry point for defining a DynamoDB table schema. Returns an object with the methods below.
+
+The double-call `<Entity>()(schema)` is required because TypeScript does not support partial type parameter inference — `Entity` is explicit while `Schema` is inferred from arguments.
+
+The optional `separator` defaults to `'#'`.
+
+### `.key(keyName, attributes, config?)`
+
+Builds a specific key value from the given attributes.
+
+```ts
+UserTable.key('PK', { orgId: 'acme', id: '123' })
+// => 'ORGID#acme#ID#123'
+
+UserTable.key('GSI1SK', { email: 'a@b.com' })
+// => 'a@b.com'
+```
+
+**`config` options:**
+
+- **`depth`** — Limit composite key to the first N components. Useful for `begins_with` queries.
+- **`allowPartial`** — When `true`, stops building the key when an attribute is missing instead of throwing. Returns a union of all valid partial prefixes at the type level.
+- **`enforceBoundary`** — When `true`, appends a trailing separator if the key is partial. Ensures a `begins_with` query doesn't match unintended prefixes.
+
+```ts
+UserTable.key('PK', { orgId: 'acme' }, { allowPartial: true })
+// => 'ORGID#acme'
+// Type: 'ORGID#acme' | `ORGID#${string}#ID#${string}`
+
+UserTable.key('PK', { orgId: 'acme', id: '1' }, { depth: 1 })
+// => 'ORGID#acme'
+
+UserTable.key('PK', { orgId: 'acme', id: '1' }, { depth: 1, enforceBoundary: true })
+// => 'ORGID#acme#'
+```
+
+### `.toEntry(item)`
+
+Converts a raw entity into a complete DynamoDB item with all keys computed.
+
+```ts
+const item = UserTable.toEntry({
+  orgId: 'acme',
+  id: '123',
+  role: 'admin',
+  email: 'a@b.com',
+})
+// => { orgId: 'acme', id: '123', role: 'admin', email: 'a@b.com',
+//      PK: 'ORGID#acme#ID#123', SK: 'ROLE#admin',
+//      GSI1PK: 'ROLE#admin', GSI1SK: 'a@b.com' }
+```
+
+Rejects excess properties at the type level.
+
+### `.fromEntry(entry)`
+
+Strips computed keys from a table entry, returning the raw entity.
+
+```ts
+const user = UserTable.fromEntry(item)
+// => { orgId: 'acme', id: '123', role: 'admin', email: 'a@b.com' }
+```
+
+### `.infer`
+
+Zero-runtime inference helper. Use with `typeof` to get the full table entry type.
+
+```ts
+type UserEntry = typeof UserTable.infer
+```
+
+### `.path()`
+
+Creates a proxy that builds DynamoDB expression paths as strings.
+
+```ts
+UserTable.path().email.toString()       // => 'email'
+UserTable.path().PK.toString()          // => 'PK'
+```
+
+## Advanced Features
+
+### Transforms
+
+Override how a field maps to its key segment using a transform function.
+
+```ts
+const Table = tableEntry<User>()({
+  PK: [
+    ['orgId', (id: string) => ({ tag: 'ORG', value: id })],
+    ['id', (id: string) => ({ tag: 'USER', value: id })],
+  ],
+  SK: ['role'],
+})
+
+Table.key('PK', { orgId: 'acme', id: '123' })
+// => 'ORG#acme#USER#123'
+```
+
+A transform returns either:
+- A `joinable` value (the field name uppercased becomes the tag)
+- `{ value }` (no tag segment emitted)
+- `{ tag, value }` (custom tag)
+
+### Discriminated Schemas
+
+When your table stores a union of entity types, use a discriminator to define per-variant key specs.
+
+```ts
+type Item =
+  | { kind: 'order'; orderId: string; userId: string }
+  | { kind: 'refund'; refundId: string; orderId: string }
+
+const ItemTable = tableEntry<Item>()({
+  PK: {
+    discriminator: 'kind',
+    spec: {
+      order: ['userId', 'orderId'],
+      refund: ['orderId', 'refundId'],
+    },
+  },
+  SK: ['kind'],
+})
+
+ItemTable.key('PK', { kind: 'order', userId: 'u1', orderId: 'o1' })
+// => 'USERID#u1#ORDERID#o1'
+
+ItemTable.key('PK', { kind: 'refund', orderId: 'o1', refundId: 'r1' })
+// => 'ORDERID#o1#REFUNDID#r1'
+```
+
+Set a discriminated spec value to `null` to produce `undefined` (useful for GSIs that don't apply to all variants).
+
+### Custom Separator
+
+```ts
+const Table = tableEntry<User>()(schema, '-')
+// Keys use '-' instead of '#': 'ORGID-acme-ID-123'
+```
+
+## Error Handling
+
+All runtime errors throw `RotoriseError` (exported), so you can distinguish library errors from your own.
+
+```ts
+import { RotoriseError } from 'rotorise'
+
+try {
+  Table.key('PK', { /* missing required attrs */ })
+} catch (e) {
+  if (e instanceof RotoriseError) { /* ... */ }
+}
+```
 
 ## Contributing
+
 Open an [issue](https://github.com/josher8a/Rotorise/issues) or a PR. We are open to any kind of contribution and feedback.
+
+## License
+
+[Apache-2.0](LICENSE)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rotorise",
-  "version": "0.2.5",
+  "version": "0.3.0",
   "description": "Supercharge your DynamoDB with Rotorise!",
   "main": "dist/Rotorise.cjs",
   "types": "dist/Rotorise.d.ts",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,9 @@
       "require": "./dist/Rotorise.cjs"
     }
   },
+  "files": [
+    "dist"
+  ],
   "type": "module",
   "keywords": [
     "AWS",
@@ -44,7 +47,6 @@
   "devDependencies": {
     "@ark/attest": "^0.34.0",
     "@biomejs/biome": "2.0.0",
-    "@swc/jest": "^0.2.36",
     "@types/node": "^18.19.34",
     "tsup": "^8.1.0",
     "typescript": "^5.4.5",

--- a/src/Rotorise.attest.test.ts
+++ b/src/Rotorise.attest.test.ts
@@ -1,0 +1,74 @@
+import { describe, it } from 'vitest'
+import { attest } from '@ark/attest'
+import { tableEntry } from './Rotorise'
+
+describe('Rotorise Performance Baseline', () => {
+    type User = {
+        id: string
+        orgId: string
+        role: 'admin' | 'user' | 'guest'
+        metadata: {
+            lastLogin: number
+            tags: string[]
+        }
+    }
+
+    const userSchema = tableEntry<User>()({
+        PK: [
+            ['orgId', (id: string) => `ORG#${id}`],
+            ['id', (id: string) => `USER#${id}`],
+        ],
+        SK: ['role'],
+        GSI1PK: [['role', (role: string) => `ROLE#${role}`]],
+    })
+
+    it('measures instantiation count for tableEntry', () => {
+        // Measure performance of the tableEntry definition
+        attest.instantiations([16, 'instantiations'])
+    })
+
+    it('measures instantiation count for key generation', () => {
+        userSchema.key('PK', { orgId: '123', id: '456' })
+        attest.instantiations([16, 'instantiations'])
+    })
+
+    it('verifies type outputs with snapshots', () => {
+        attest(
+            userSchema.key('PK', { orgId: '123', id: '456' }),
+        ).type.toString.snap('`ORGID#${string}#ID#${string}`')
+        attest(userSchema.key('SK', { role: 'admin' })).type.toString.snap(
+            '"ROLE#admin"',
+        )
+    })
+
+    describe('Error Diagnostics', () => {
+        it('reports error for invalid schema key', () => {
+            const invalidSchema = tableEntry<User>()({
+                // @ts-expect-error
+                INVALID: 123,
+            })
+            attest(
+                invalidSchema.infer.INVALID,
+            ).type.toString.snap(`  | ErrorMessage<"Invalid schema definition">
+  | undefined`)
+        })
+
+        it('reports error for invalid top-level key in .key()', () => {
+            attest(() =>
+                // @ts-expect-error
+                userSchema.key('NON_EXISTENT', { id: '123' }),
+            ).throws.snap('Error: Key NON_EXISTENT not found in schema')
+        })
+
+        it('reports error for invalid Spec type', () => {
+            const invalidSchema = tableEntry<User>()({
+                // @ts-expect-error
+                BAD_SPEC: { invalid: 'logic' },
+            })
+            attest(
+                invalidSchema.infer.BAD_SPEC,
+            ).type.toString.snap(`  | ErrorMessage<"Invalid schema definition">
+  | undefined`)
+        })
+    })
+})

--- a/src/Rotorise.attest.test.ts
+++ b/src/Rotorise.attest.test.ts
@@ -57,7 +57,7 @@ describe('Rotorise Performance Baseline', () => {
             attest(() =>
                 // @ts-expect-error
                 userSchema.key('NON_EXISTENT', { id: '123' }),
-            ).throws.snap('Error: Key NON_EXISTENT not found in schema')
+            ).throws.snap('RotoriseError: Key NON_EXISTENT not found in schema')
         })
 
         it('reports error for invalid Spec type', () => {

--- a/src/Rotorise.spec.ts
+++ b/src/Rotorise.spec.ts
@@ -6,7 +6,7 @@ import {
     type TransformShape,
     tableEntry,
 } from './Rotorise'
-import type { NonEmptyArray } from './utils'
+import type { NonEmptyArray, show } from './utils'
 
 type Equal<T, U> = (<G>() => G extends T ? 1 : 2) extends <G>() => G extends U
     ? 1
@@ -57,7 +57,7 @@ describe('DynamoDB Utils', () => {
                   >
               >
 
-        attest.instantiations([1721, 'instantiations'])
+        attest.instantiations([1726, 'instantiations'])
     })
 
     it('CompositeKeyBuilder', () => {
@@ -377,7 +377,7 @@ describe('DynamoDB Utils', () => {
             ),
         ).toBe(1)
 
-        attest.instantiations([8114, 'instantiations'])
+        attest.instantiations([7674, 'instantiations'])
     })
 
     test('path from infer then toString', () => {
@@ -598,9 +598,7 @@ describe('DynamoDB Utils', () => {
             '-',
         )
 
-        testTableEntry
-
-        type entries =
+        type entries = show<
             | ({
                   a: 'a1'
                   b: 1n
@@ -627,6 +625,7 @@ describe('DynamoDB Utils', () => {
                   readonly GSI1SK: 2
                   readonly GSI2PK: 2
               })
+        >
 
         type expect_infer = isTrue<Equal<typeof testTableEntry.infer, entries>>
 
@@ -729,7 +728,7 @@ describe('DynamoDB Utils', () => {
             }),
         ).toBeUndefined()
 
-        attest.instantiations([61230, 'instantiations'])
+        attest.instantiations([61103, 'instantiations'])
     })
 
     test('real world example', () => {
@@ -850,33 +849,35 @@ describe('DynamoDB Utils', () => {
             },
         })
 
-        let expect_infer: isTrue<
+        type expect_infer = isTrue<
             Equal<
                 RealEntry,
-                | (A & {
-                      readonly PK: `ID1#${string}#USER#${string}`
-                      readonly SK: `TAG#A#ID2#${string}#TYPE#TypeA`
-                      readonly GSI1PK: `ID2#${string}`
-                      readonly GSI1SK: `TYPE#TypeA`
-                  })
-                | ({
-                      readonly PK: `ID1#${string}#USER#${string}`
-                      readonly SK: `TAG#C#ID2#${string}#TYPE#TypeB`
-                      readonly GSI1PK: `ID2#${string}`
-                      readonly GSI1SK: `TYPE#TypeB`
-                  } & C)
-                | ({
-                      readonly PK: `ID1#${string}#USER#${string}`
-                      readonly SK: `TAG#D#ID2#${string}#KIND#${string}#TYPE#TypeA`
-                      readonly GSI1PK: `ID2#${string}`
-                      readonly GSI1SK: `KIND#${string}`
-                  } & D)
-                | ({
-                      readonly PK: `ID1#${string}#USER#${string}`
-                      readonly SK: `TAG#B#ID2#${string}#TYPE#TypeB`
-                      readonly GSI1PK: `ID2#${string}`
-                      readonly GSI1SK: `TYPE#TypeB`
-                  } & B)
+                show<
+                    | (A & {
+                          readonly PK: `ID1#${string}#USER#${string}`
+                          readonly SK: `TAG#A#ID2#${string}#TYPE#TypeA`
+                          readonly GSI1PK: `ID2#${string}`
+                          readonly GSI1SK: `TYPE#TypeA`
+                      })
+                    | ({
+                          readonly PK: `ID1#${string}#USER#${string}`
+                          readonly SK: `TAG#C#ID2#${string}#TYPE#TypeB`
+                          readonly GSI1PK: `ID2#${string}`
+                          readonly GSI1SK: `TYPE#TypeB`
+                      } & C)
+                    | ({
+                          readonly PK: `ID1#${string}#USER#${string}`
+                          readonly SK: `TAG#D#ID2#${string}#KIND#${string}#TYPE#TypeA`
+                          readonly GSI1PK: `ID2#${string}`
+                          readonly GSI1SK: `KIND#${string}`
+                      } & D)
+                    | ({
+                          readonly PK: `ID1#${string}#USER#${string}`
+                          readonly SK: `TAG#B#ID2#${string}#TYPE#TypeB`
+                          readonly GSI1PK: `ID2#${string}`
+                          readonly GSI1SK: `TYPE#TypeB`
+                      } & B)
+                >
             >
         >
 
@@ -1062,7 +1063,7 @@ describe('DynamoDB Utils', () => {
             '-',
         )
 
-        type entries =
+        type entries = show<
             | ({
                   a: 'a1'
                   b: 1n
@@ -1085,6 +1086,7 @@ describe('DynamoDB Utils', () => {
                   readonly GSIPK: 'never' | undefined
                   readonly GSISK: 'Z-never' | 'Z-DEFAULT'
               })
+        >
 
         type expect_infer = isTrue<Equal<typeof testTableEntry.infer, entries>>
 

--- a/src/Rotorise.spec.ts
+++ b/src/Rotorise.spec.ts
@@ -8,205 +8,167 @@ import {
 } from './Rotorise'
 import type { NonEmptyArray, show } from './utils'
 
-type Equal<T, U> = (<G>() => G extends T ? 1 : 2) extends <G>() => G extends U
-    ? 1
-    : 2
-    ? true
-    : false
-type isTrue<T extends true> = T
-
 describe('DynamoDB Utils', () => {
     it('CompositeKeyParams', () => {
-        type test_CompositeKeyParams =
-            | isTrue<
-                  Equal<
-                      CompositeKeyParams<
-                          { a: string; b: number; c: boolean },
-                          ['a', 'b', 'c']
-                      >,
-                      { a: string; b?: number; c?: boolean }
-                  >
-              >
-            | isTrue<
-                  Equal<
-                      CompositeKeyParams<
-                          { a: string; b: number; c: boolean },
-                          ['a', 'b', ['c', (c: boolean) => 'TRANSFORM']]
-                      >,
-                      { a: string; b?: number; c?: boolean }
-                  >
-              >
-            | isTrue<
-                  Equal<
-                      CompositeKeyParams<
-                          { a: string; b: number; c: boolean },
-                          ['a', 'b', ['c', (c: boolean) => 'TRANSFORM']],
-                          2
-                      >,
-                      { a: string; b: number; c?: boolean }
-                  >
-              >
-            | isTrue<
-                  Equal<
-                      CompositeKeyParams<
-                          { a: string; b: number; c: boolean },
-                          ['a', 'b', ['c', (c: boolean) => 'TRANSFORM']],
-                          number
-                      >,
-                      { a: string; b?: number; c?: boolean }
-                  >
-              >
+        attest<{ a: string; b?: number; c?: boolean }>(
+            null as any as CompositeKeyParams<
+                { a: string; b: number; c: boolean },
+                ['a', 'b', 'c']
+            >,
+        )
+        attest<{ a: string; b?: number; c?: boolean }>(
+            null as any as CompositeKeyParams<
+                { a: string; b: number; c: boolean },
+                ['a', 'b', ['c', (c: boolean) => 'TRANSFORM']]
+            >,
+        )
+        attest<{ a: string; b: number; c?: boolean }>(
+            null as any as CompositeKeyParams<
+                { a: string; b: number; c: boolean },
+                ['a', 'b', ['c', (c: boolean) => 'TRANSFORM']],
+                2
+            >,
+        )
+        attest<{ a: string; b?: number; c?: boolean }>(
+            null as any as CompositeKeyParams<
+                { a: string; b: number; c: boolean },
+                ['a', 'b', ['c', (c: boolean) => 'TRANSFORM']],
+                number
+            >,
+        )
 
         attest.instantiations([1726, 'instantiations'])
     })
 
     it('CompositeKeyBuilder', () => {
-        type test_CompositeKeyBuilder =
-            | isTrue<
-                  Equal<
-                      CompositeKeyBuilder<
-                          { a: string; b: number; c: boolean },
-                          ['a', 'b', 'c']
-                      >,
-                      `A#${string}#B#${number}#C#${boolean}`
-                  >
-              >
-            | isTrue<
-                  Equal<
-                      CompositeKeyBuilder<
-                          | { a: 'a1'; b: 1; c: true; z: never }
-                          | { a: 'a2'; b: 2; c: true; z: never },
-                          ['a', 'b']
-                      >,
-                      `A#${'a1'}#B#${1}` | `A#${'a2'}#B#${2}`
-                  >
-              >
-            | isTrue<
-                  Equal<
-                      CompositeKeyBuilder<
-                          { a: string; b: number; c: boolean },
-                          ['a', 'b', 'c'],
-                          '-'
-                      >,
-                      `A-${string}-B-${number}-C-${boolean}`
-                  >
-              >
-            | isTrue<
-                  Equal<
-                      CompositeKeyBuilder<
-                          { a: string; b: number; c: boolean },
-                          ['a', 'b', 'c'],
-                          '-',
-                          2
-                      >,
-                      `A-${string}-B-${number}`
-                  >
-              >
-            | isTrue<
-                  Equal<
-                      CompositeKeyBuilder<
-                          { a: string; b: number; c: boolean },
-                          ['a', 'b', 'c'],
-                          '-',
-                          3,
-                          true
-                      >,
-                      | `A-${string}`
-                      | `A-${string}-B-${number}`
-                      | `A-${string}-B-${number}-C-${boolean}`
-                  >
-              >
-            | isTrue<
-                  Equal<
-                      CompositeKeyBuilder<
-                          | { a: 'a1'; b: 1; c: true; z: never }
-                          | { a: 'a2'; b: 2; c: false; z: never },
-                          ['a', 'b', 'c'],
-                          '#',
-                          3,
-                          true
-                      >,
-                      | 'A#a1'
-                      | 'A#a1#B#1'
-                      | 'A#a1#B#1#C#true'
-                      | 'A#a2'
-                      | 'A#a2#B#2'
-                      | 'A#a2#B#2#C#false'
-                  >
-              >
-            | isTrue<
-                  Equal<
-                      CompositeKeyBuilder<
-                          | { a: 'a1'; b: 1; c: true; z: never }
-                          | { a: 'a2'; b: 2; c: false; z: never },
-                          ['a', 'b', ['c', (c: boolean) => 'TRANSFORM']],
-                          '#',
-                          3,
-                          true
-                      >,
-                      | 'A#a1'
-                      | 'A#a1#B#1'
-                      | 'A#a2'
-                      | 'A#a2#B#2'
-                      | 'A#a1#B#1#C#TRANSFORM'
-                      | 'A#a2#B#2#C#TRANSFORM'
-                  >
-              >
-            | isTrue<
-                  Equal<
-                      CompositeKeyBuilder<
-                          | { a: 'a1'; b: 1; c: true; z: never }
-                          | { a: 'a2'; b: 2; c: false; z: never },
-                          [
-                              'a',
-                              'b',
-                              [
-                                  'c',
-                                  (c: boolean) => {
-                                      tag: 'TAG'
-                                      value: 'TRANSFORM'
-                                  },
-                              ],
-                          ],
-                          '#',
-                          3,
-                          true
-                      >,
-                      | 'A#a1'
-                      | 'A#a1#B#1'
-                      | 'A#a2'
-                      | 'A#a2#B#2'
-                      | 'A#a1#B#1#TAG#TRANSFORM'
-                      | 'A#a2#B#2#TAG#TRANSFORM'
-                  >
-              >
-            | isTrue<
-                  Equal<
-                      CompositeKeyBuilder<
-                          | { a: 'a1'; b: 1; c: true; z: never }
-                          | { a: 'a2'; b: 2; c: false; z: never },
-                          [
-                              'a',
-                              'b',
-                              [
-                                  'c',
-                                  (c: boolean) => {
-                                      value: 'TRANSFORM'
-                                  },
-                              ],
-                          ],
-                          '#',
-                          3,
-                          true
-                      >,
-                      | 'A#a1'
-                      | 'A#a1#B#1'
-                      | 'A#a2'
-                      | 'A#a2#B#2'
-                      | 'A#a1#B#1#TRANSFORM'
-                      | 'A#a2#B#2#TRANSFORM'
-                  >
-              >
+        attest<`A#${string}#B#${number}#C#${boolean}`>(
+            null as any as CompositeKeyBuilder<
+                { a: string; b: number; c: boolean },
+                ['a', 'b', 'c']
+            >,
+        )
+        attest<`A#${'a1'}#B#${1}` | `A#${'a2'}#B#${2}`>(
+            null as any as CompositeKeyBuilder<
+                | { a: 'a1'; b: 1; c: true; z: never }
+                | { a: 'a2'; b: 2; c: true; z: never },
+                ['a', 'b']
+            >,
+        )
+        attest<`A-${string}-B-${number}-C-${boolean}`>(
+            null as any as CompositeKeyBuilder<
+                { a: string; b: number; c: boolean },
+                ['a', 'b', 'c'],
+                '-'
+            >,
+        )
+        attest<`A-${string}-B-${number}`>(
+            null as any as CompositeKeyBuilder<
+                { a: string; b: number; c: boolean },
+                ['a', 'b', 'c'],
+                '-',
+                2
+            >,
+        )
+        attest<
+            | `A-${string}`
+            | `A-${string}-B-${number}`
+            | `A-${string}-B-${number}-C-${boolean}`
+        >(
+            null as any as CompositeKeyBuilder<
+                { a: string; b: number; c: boolean },
+                ['a', 'b', 'c'],
+                '-',
+                3,
+                true
+            >,
+        )
+        attest<
+            | 'A#a1'
+            | 'A#a1#B#1'
+            | 'A#a1#B#1#C#true'
+            | 'A#a2'
+            | 'A#a2#B#2'
+            | 'A#a2#B#2#C#false'
+        >(
+            null as any as CompositeKeyBuilder<
+                | { a: 'a1'; b: 1; c: true; z: never }
+                | { a: 'a2'; b: 2; c: false; z: never },
+                ['a', 'b', 'c'],
+                '#',
+                3,
+                true
+            >,
+        )
+        attest<
+            | 'A#a1'
+            | 'A#a1#B#1'
+            | 'A#a2'
+            | 'A#a2#B#2'
+            | 'A#a1#B#1#C#TRANSFORM'
+            | 'A#a2#B#2#C#TRANSFORM'
+        >(
+            null as any as CompositeKeyBuilder<
+                | { a: 'a1'; b: 1; c: true; z: never }
+                | { a: 'a2'; b: 2; c: false; z: never },
+                ['a', 'b', ['c', (c: boolean) => 'TRANSFORM']],
+                '#',
+                3,
+                true
+            >,
+        )
+        attest<
+            | 'A#a1'
+            | 'A#a1#B#1'
+            | 'A#a2'
+            | 'A#a2#B#2'
+            | 'A#a1#B#1#TAG#TRANSFORM'
+            | 'A#a2#B#2#TAG#TRANSFORM'
+        >(
+            null as any as CompositeKeyBuilder<
+                | { a: 'a1'; b: 1; c: true; z: never }
+                | { a: 'a2'; b: 2; c: false; z: never },
+                [
+                    'a',
+                    'b',
+                    [
+                        'c',
+                        (c: boolean) => {
+                            tag: 'TAG'
+                            value: 'TRANSFORM'
+                        },
+                    ],
+                ],
+                '#',
+                3,
+                true
+            >,
+        )
+        attest<
+            | 'A#a1'
+            | 'A#a1#B#1'
+            | 'A#a2'
+            | 'A#a2#B#2'
+            | 'A#a1#B#1#TRANSFORM'
+            | 'A#a2#B#2#TRANSFORM'
+        >(
+            null as any as CompositeKeyBuilder<
+                | { a: 'a1'; b: 1; c: true; z: never }
+                | { a: 'a2'; b: 2; c: false; z: never },
+                [
+                    'a',
+                    'b',
+                    [
+                        'c',
+                        (c: boolean) => {
+                            value: 'TRANSFORM'
+                        },
+                    ],
+                ],
+                '#',
+                3,
+                true
+            >,
+        )
 
         attest.instantiations([5778, 'instantiations'])
     })
@@ -307,9 +269,10 @@ describe('DynamoDB Utils', () => {
 
         const fromEntry = testTableEntry.fromEntry(testTableEntryObj)
 
-        type expect_fromEntry =
-            | isTrue<Equal<ReturnType<typeof testTableEntry.fromEntry>, Entity>>
-            | isTrue<Equal<typeof fromEntry, typeof entity>> // narrow down to the exact type
+        attest<Entity>(
+            null as any as ReturnType<typeof testTableEntry.fromEntry>,
+        )
+        attest<typeof entity>(fromEntry) // narrow down to the exact type
 
         expect(fromEntry).toEqual(entity)
 
@@ -325,9 +288,7 @@ describe('DynamoDB Utils', () => {
             },
         )
 
-        type test_buildCompositeKey = isTrue<
-            Equal<typeof key, 'A-a1-B-1' | 'A-a1'>
-        >
+        attest<'A-a1-B-1' | 'A-a1'>(key)
 
         expect(key).toBe('A-a1-B-1')
 
@@ -337,9 +298,7 @@ describe('DynamoDB Utils', () => {
             c: true,
         })
 
-        type test_buildCompositeKeyDefaults = isTrue<
-            Equal<typeof keyDefaults, 'A-a1-B-1-C-true'>
-        >
+        attest<'A-a1-B-1-C-true'>(keyDefaults)
 
         expect(keyDefaults).toBe('A-a1-B-1-C-true')
 
@@ -428,129 +387,104 @@ describe('DynamoDB Utils', () => {
             }
         >['spec']['a1']
 
-        type expect_schema = isTrue<
-            Equal<
-                Parameters<typeof base>,
-                [
-                    schema: Record<
-                        string,
-                        | 'a'
-                        | 'b'
-                        | 'c'
-                        | 'z'
-                        | NonEmptyArray<
-                              | 'a'
-                              | 'b'
-                              | 'c'
-                              | 'z'
-                              | ['a', (key: 'a1' | 'a2') => TransformShape]
-                              | ['b', (key: 1n | 2) => TransformShape]
-                              | ['c', (key: true | 0) => TransformShape]
-                              | ['z', (key: 'never') => TransformShape]
-                          >
-                        | null
-                        | {
-                              discriminator: 'a'
-                              spec: {
-                                  a1:
-                                      | 'a'
-                                      | 'b'
-                                      | 'c'
-                                      | 'z'
-                                      | NonEmptyArray<
-                                            | 'a'
-                                            | 'b'
-                                            | 'c'
-                                            | 'z'
-                                            | [
-                                                  'a',
-                                                  (key: 'a1') => TransformShape,
-                                              ]
-                                            | ['b', (key: 1n) => TransformShape]
-                                            | [
-                                                  'c',
-                                                  (key: true) => TransformShape,
-                                              ]
-                                            | [
-                                                  'z',
-                                                  (
-                                                      key: 'never',
-                                                  ) => TransformShape,
-                                              ]
-                                        >
-                                      | null
-                                  a2:
-                                      | 'a'
-                                      | 'b'
-                                      | 'c'
-                                      | 'z'
-                                      | NonEmptyArray<
-                                            | 'a'
-                                            | 'b'
-                                            | 'c'
-                                            | 'z'
-                                            | [
-                                                  'a',
-                                                  (key: 'a2') => TransformShape,
-                                              ]
-                                            | ['b', (key: 2) => TransformShape]
-                                            | ['c', (key: 0) => TransformShape]
-                                            | [
-                                                  'z',
-                                                  (
-                                                      key: 'never',
-                                                  ) => TransformShape,
-                                              ]
-                                        >
-                                      | null
-                              }
+        attest<
+            [
+                schema: Record<
+                    string,
+                    | 'a'
+                    | 'b'
+                    | 'c'
+                    | 'z'
+                    | NonEmptyArray<
+                          | 'a'
+                          | 'b'
+                          | 'c'
+                          | 'z'
+                          | ['a', (key: 'a1' | 'a2') => TransformShape]
+                          | ['b', (key: 1n | 2) => TransformShape]
+                          | ['c', (key: true | 0) => TransformShape]
+                          | ['z', (key: 'never') => TransformShape]
+                      >
+                    | null
+                    | {
+                          discriminator: 'a'
+                          spec: {
+                              a1:
+                                  | 'a'
+                                  | 'b'
+                                  | 'c'
+                                  | 'z'
+                                  | NonEmptyArray<
+                                        | 'a'
+                                        | 'b'
+                                        | 'c'
+                                        | 'z'
+                                        | ['a', (key: 'a1') => TransformShape]
+                                        | ['b', (key: 1n) => TransformShape]
+                                        | ['c', (key: true) => TransformShape]
+                                        | [
+                                              'z',
+                                              (key: 'never') => TransformShape,
+                                          ]
+                                    >
+                                  | null
+                              a2:
+                                  | 'a'
+                                  | 'b'
+                                  | 'c'
+                                  | 'z'
+                                  | NonEmptyArray<
+                                        | 'a'
+                                        | 'b'
+                                        | 'c'
+                                        | 'z'
+                                        | ['a', (key: 'a2') => TransformShape]
+                                        | ['b', (key: 2) => TransformShape]
+                                        | ['c', (key: 0) => TransformShape]
+                                        | [
+                                              'z',
+                                              (key: 'never') => TransformShape,
+                                          ]
+                                    >
+                                  | null
                           }
-                        | {
-                              discriminator: 'z'
-                              spec: {
-                                  never:
-                                      | 'a'
-                                      | 'b'
-                                      | 'c'
-                                      | 'z'
-                                      | NonEmptyArray<
-                                            | 'a'
-                                            | 'b'
-                                            | 'c'
-                                            | 'z'
-                                            | [
-                                                  'a',
-                                                  (
-                                                      key: 'a1' | 'a2',
-                                                  ) => TransformShape,
-                                              ]
-                                            | [
-                                                  'b',
-                                                  (
-                                                      key: 2 | 1n,
-                                                  ) => TransformShape,
-                                              ]
-                                            | [
-                                                  'c',
-                                                  (
-                                                      key: true | 0,
-                                                  ) => TransformShape,
-                                              ]
-                                            | [
-                                                  'z',
-                                                  (
-                                                      key: 'never',
-                                                  ) => TransformShape,
-                                              ]
-                                        >
-                                      | null
-                              }
+                      }
+                    | {
+                          discriminator: 'z'
+                          spec: {
+                              never:
+                                  | 'a'
+                                  | 'b'
+                                  | 'c'
+                                  | 'z'
+                                  | NonEmptyArray<
+                                        | 'a'
+                                        | 'b'
+                                        | 'c'
+                                        | 'z'
+                                        | [
+                                              'a',
+                                              (
+                                                  key: 'a1' | 'a2',
+                                              ) => TransformShape,
+                                          ]
+                                        | ['b', (key: 2 | 1n) => TransformShape]
+                                        | [
+                                              'c',
+                                              (key: true | 0) => TransformShape,
+                                          ]
+                                        | [
+                                              'z',
+                                              (key: 'never') => TransformShape,
+                                          ]
+                                    >
+                                  | null
                           }
-                    >,
-                    separator?: string | undefined,
-                ]
-            >
-        >
+                      }
+                >,
+                separator?: string | undefined,
+            ]
+        >(null as any as Parameters<typeof base>)
 
         const testTableEntry = base(
             {
@@ -627,7 +561,7 @@ describe('DynamoDB Utils', () => {
               })
         >
 
-        type expect_infer = isTrue<Equal<typeof testTableEntry.infer, entries>>
+        attest<entries>(testTableEntry.infer)
 
         expect(
             testTableEntry.key(
@@ -849,37 +783,34 @@ describe('DynamoDB Utils', () => {
             },
         })
 
-        type expect_infer = isTrue<
-            Equal<
-                RealEntry,
-                show<
-                    | (A & {
-                          readonly PK: `ID1#${string}#USER#${string}`
-                          readonly SK: `TAG#A#ID2#${string}#TYPE#TypeA`
-                          readonly GSI1PK: `ID2#${string}`
-                          readonly GSI1SK: `TYPE#TypeA`
-                      })
-                    | ({
-                          readonly PK: `ID1#${string}#USER#${string}`
-                          readonly SK: `TAG#C#ID2#${string}#TYPE#TypeB`
-                          readonly GSI1PK: `ID2#${string}`
-                          readonly GSI1SK: `TYPE#TypeB`
-                      } & C)
-                    | ({
-                          readonly PK: `ID1#${string}#USER#${string}`
-                          readonly SK: `TAG#D#ID2#${string}#KIND#${string}#TYPE#TypeA`
-                          readonly GSI1PK: `ID2#${string}`
-                          readonly GSI1SK: `KIND#${string}`
-                      } & D)
-                    | ({
-                          readonly PK: `ID1#${string}#USER#${string}`
-                          readonly SK: `TAG#B#ID2#${string}#TYPE#TypeB`
-                          readonly GSI1PK: `ID2#${string}`
-                          readonly GSI1SK: `TYPE#TypeB`
-                      } & B)
-                >
+        attest<
+            show<
+                | (A & {
+                      readonly PK: `ID1#${string}#USER#${string}`
+                      readonly SK: `TAG#A#ID2#${string}#TYPE#TypeA`
+                      readonly GSI1PK: `ID2#${string}`
+                      readonly GSI1SK: `TYPE#TypeA`
+                  })
+                | ({
+                      readonly PK: `ID1#${string}#USER#${string}`
+                      readonly SK: `TAG#C#ID2#${string}#TYPE#TypeB`
+                      readonly GSI1PK: `ID2#${string}`
+                      readonly GSI1SK: `TYPE#TypeB`
+                  } & C)
+                | ({
+                      readonly PK: `ID1#${string}#USER#${string}`
+                      readonly SK: `TAG#D#ID2#${string}#KIND#${string}#TYPE#TypeA`
+                      readonly GSI1PK: `ID2#${string}`
+                      readonly GSI1SK: `KIND#${string}`
+                  } & D)
+                | ({
+                      readonly PK: `ID1#${string}#USER#${string}`
+                      readonly SK: `TAG#B#ID2#${string}#TYPE#TypeB`
+                      readonly GSI1PK: `ID2#${string}`
+                      readonly GSI1SK: `TYPE#TypeB`
+                  } & B)
             >
-        >
+        >(null as any as RealEntry)
 
         const expect_key = RealEntry.key(
             'PK',
@@ -933,12 +864,9 @@ describe('DynamoDB Utils', () => {
             { allowPartial: true, depth: 2 },
         ) satisfies 'TAG#A' | `TAG#A#ID2#${string}`
 
-        type expect_key_depth_partial_discriminator = isTrue<
-            Equal<
-                typeof expect_key_depth_partial_discriminator,
-                'TAG#A' | `TAG#A#ID2#yolo`
-            >
-        >
+        attest<'TAG#A' | `TAG#A#ID2#yolo`>(
+            expect_key_depth_partial_discriminator,
+        )
 
         const expect_key_depth_discriminator = RealEntry.key(
             'SK',
@@ -955,91 +883,77 @@ describe('DynamoDB Utils', () => {
             | { a: 'a2'; b: 2; c: 0; z?: 'never' | null }
         >()
 
-        type expect_schema = isTrue<
-            Equal<
-                Parameters<typeof base>,
-                [
-                    schema: Record<
-                        string,
-                        | 'a'
-                        | 'b'
-                        | 'c'
-                        | 'z'
-                        | NonEmptyArray<
-                              | 'a'
-                              | 'b'
-                              | 'c'
-                              | ['a', (key: 'a1' | 'a2') => TransformShape]
-                              | ['b', (key: 1n | 2) => TransformShape]
-                              | ['c', (key: true | 0) => TransformShape]
-                              | [
-                                    'z',
-                                    (key: 'never' | null) => TransformShape,
-                                    'never' | null,
-                                ]
-                          >
-                        | null
-                        | {
-                              discriminator: 'a'
-                              spec: {
-                                  a1:
-                                      | 'a'
-                                      | 'b'
-                                      | 'c'
-                                      | 'z'
-                                      | NonEmptyArray<
-                                            | 'a'
-                                            | 'b'
-                                            | 'c'
-                                            | 'z'
-                                            | [
-                                                  'a',
-                                                  (key: 'a1') => TransformShape,
-                                              ]
-                                            | ['b', (key: 1n) => TransformShape]
-                                            | [
-                                                  'c',
-                                                  (key: true) => TransformShape,
-                                              ]
-                                            | [
-                                                  'z',
-                                                  (
-                                                      key: 'never',
-                                                  ) => TransformShape,
-                                              ]
-                                        >
-                                      | null
-                                  a2:
-                                      | 'a'
-                                      | 'b'
-                                      | 'c'
-                                      | 'z'
-                                      | NonEmptyArray<
-                                            | 'a'
-                                            | 'b'
-                                            | 'c'
-                                            | [
-                                                  'a',
-                                                  (key: 'a2') => TransformShape,
-                                              ]
-                                            | ['b', (key: 2) => TransformShape]
-                                            | ['c', (key: 0) => TransformShape]
-                                            | [
-                                                  'z',
-                                                  (
-                                                      key: 'never' | null,
-                                                  ) => TransformShape,
-                                                  'never' | null,
-                                              ]
-                                        >
-                                      | null
-                              }
+        attest<
+            [
+                schema: Record<
+                    string,
+                    | 'a'
+                    | 'b'
+                    | 'c'
+                    | 'z'
+                    | NonEmptyArray<
+                          | 'a'
+                          | 'b'
+                          | 'c'
+                          | ['a', (key: 'a1' | 'a2') => TransformShape]
+                          | ['b', (key: 1n | 2) => TransformShape]
+                          | ['c', (key: true | 0) => TransformShape]
+                          | [
+                                'z',
+                                (key: 'never' | null) => TransformShape,
+                                'never' | null,
+                            ]
+                      >
+                    | null
+                    | {
+                          discriminator: 'a'
+                          spec: {
+                              a1:
+                                  | 'a'
+                                  | 'b'
+                                  | 'c'
+                                  | 'z'
+                                  | NonEmptyArray<
+                                        | 'a'
+                                        | 'b'
+                                        | 'c'
+                                        | 'z'
+                                        | ['a', (key: 'a1') => TransformShape]
+                                        | ['b', (key: 1n) => TransformShape]
+                                        | ['c', (key: true) => TransformShape]
+                                        | [
+                                              'z',
+                                              (key: 'never') => TransformShape,
+                                          ]
+                                    >
+                                  | null
+                              a2:
+                                  | 'a'
+                                  | 'b'
+                                  | 'c'
+                                  | 'z'
+                                  | NonEmptyArray<
+                                        | 'a'
+                                        | 'b'
+                                        | 'c'
+                                        | ['a', (key: 'a2') => TransformShape]
+                                        | ['b', (key: 2) => TransformShape]
+                                        | ['c', (key: 0) => TransformShape]
+                                        | [
+                                              'z',
+                                              (
+                                                  key: 'never' | null,
+                                              ) => TransformShape,
+                                              'never' | null,
+                                          ]
+                                    >
+                                  | null
                           }
-                    >,
-                    separator?: string | undefined,
-                ]
-            >
-        >
+                      }
+                >,
+                separator?: string | undefined,
+            ]
+        >(null as any as Parameters<typeof base>)
 
         const testTableEntry = base(
             {
@@ -1088,7 +1002,7 @@ describe('DynamoDB Utils', () => {
               })
         >
 
-        type expect_infer = isTrue<Equal<typeof testTableEntry.infer, entries>>
+        attest<entries>(testTableEntry.infer)
 
         expect(
             testTableEntry.key('SK', {
@@ -1122,64 +1036,53 @@ describe('DynamoDB Utils', () => {
             { a: 'a1'; b: 1n; extra: 'extra' } | { a: 'a2'; b: 2 }
         >()
 
-        type expect_schema = isTrue<
-            Equal<
-                Parameters<typeof base>,
-                [
-                    schema: Record<
-                        string,
-                        | 'a'
-                        | 'b'
-                        | NonEmptyArray<
-                              | 'a'
-                              | 'b'
-                              | ['a', (key: 'a1' | 'a2') => TransformShape]
-                              | ['b', (key: 1n | 2) => TransformShape]
-                          >
-                        | null
-                        | {
-                              discriminator: 'a'
-                              spec: {
-                                  a1:
-                                      | 'a'
-                                      | 'b'
-                                      | 'extra'
-                                      | NonEmptyArray<
-                                            | 'a'
-                                            | 'b'
-                                            | 'extra'
-                                            | [
-                                                  'a',
-                                                  (key: 'a1') => TransformShape,
-                                              ]
-                                            | ['b', (key: 1n) => TransformShape]
-                                            | [
-                                                  'extra',
-                                                  (
-                                                      key: 'extra',
-                                                  ) => TransformShape,
-                                              ]
-                                        >
-                                      | null
-                                  a2:
-                                      | 'a'
-                                      | 'b'
-                                      | NonEmptyArray<
-                                            | 'a'
-                                            | 'b'
-                                            | [
-                                                  'a',
-                                                  (key: 'a2') => TransformShape,
-                                              ]
-                                            | ['b', (key: 2) => TransformShape]
-                                        >
-                                      | null
-                              }
+        attest<
+            [
+                schema: Record<
+                    string,
+                    | 'a'
+                    | 'b'
+                    | NonEmptyArray<
+                          | 'a'
+                          | 'b'
+                          | ['a', (key: 'a1' | 'a2') => TransformShape]
+                          | ['b', (key: 1n | 2) => TransformShape]
+                      >
+                    | null
+                    | {
+                          discriminator: 'a'
+                          spec: {
+                              a1:
+                                  | 'a'
+                                  | 'b'
+                                  | 'extra'
+                                  | NonEmptyArray<
+                                        | 'a'
+                                        | 'b'
+                                        | 'extra'
+                                        | ['a', (key: 'a1') => TransformShape]
+                                        | ['b', (key: 1n) => TransformShape]
+                                        | [
+                                              'extra',
+                                              (key: 'extra') => TransformShape,
+                                          ]
+                                    >
+                                  | null
+                              a2:
+                                  | 'a'
+                                  | 'b'
+                                  | NonEmptyArray<
+                                        | 'a'
+                                        | 'b'
+                                        | ['a', (key: 'a2') => TransformShape]
+                                        | ['b', (key: 2) => TransformShape]
+                                    >
+                                  | null
                           }
-                    >,
-                    separator?: string | undefined,
-                ]
-            >
-        >
+                      }
+                >,
+                separator?: string | undefined,
+            ]
+        >(null as any as Parameters<typeof base>)
     })
 })

--- a/src/Rotorise.spec.ts
+++ b/src/Rotorise.spec.ts
@@ -377,7 +377,7 @@ describe('DynamoDB Utils', () => {
             ),
         ).toBe(1)
 
-        attest.instantiations([10981, 'instantiations'])
+        attest.instantiations([9615, 'instantiations'])
     })
 
     test('path from infer then toString', () => {
@@ -729,7 +729,7 @@ describe('DynamoDB Utils', () => {
             }),
         ).toBeUndefined()
 
-        attest.instantiations([63523, 'instantiations'])
+        attest.instantiations([61232, 'instantiations'])
     })
 
     test('real world example', () => {
@@ -945,7 +945,7 @@ describe('DynamoDB Utils', () => {
             { depth: 2 },
         ) satisfies 'TAG#A#ID2#yolo'
 
-        attest.instantiations([33275, 'instantiations'])
+        attest.instantiations([31539, 'instantiations'])
     })
 
     test('schema allows for nullish values if has transform', () => {

--- a/src/Rotorise.spec.ts
+++ b/src/Rotorise.spec.ts
@@ -377,7 +377,7 @@ describe('DynamoDB Utils', () => {
             ),
         ).toBe(1)
 
-        attest.instantiations([11890, 'instantiations'])
+        attest.instantiations([11700, 'instantiations'])
     })
 
     test('path from infer then toString', () => {
@@ -413,7 +413,7 @@ describe('DynamoDB Utils', () => {
         )
         expect(testTableEntry.path().PK.toString()).toBe('PK')
 
-        attest.instantiations([1244, 'instantiations'])
+        attest.instantiations([1169, 'instantiations'])
     })
 
     test('table Entry with transform and discriminator ', () => {
@@ -729,7 +729,7 @@ describe('DynamoDB Utils', () => {
             }),
         ).toBeUndefined()
 
-        attest.instantiations([64942, 'instantiations'])
+        attest.instantiations([64583, 'instantiations'])
     })
 
     test('real world example', () => {
@@ -945,7 +945,7 @@ describe('DynamoDB Utils', () => {
             { depth: 2 },
         ) satisfies 'TAG#A#ID2#yolo'
 
-        attest.instantiations([36632, 'instantiations'])
+        attest.instantiations([35984, 'instantiations'])
     })
 
     test('schema allows for nullish values if has transform', () => {

--- a/src/Rotorise.spec.ts
+++ b/src/Rotorise.spec.ts
@@ -377,7 +377,7 @@ describe('DynamoDB Utils', () => {
             ),
         ).toBe(1)
 
-        attest.instantiations([9615, 'instantiations'])
+        attest.instantiations([8114, 'instantiations'])
     })
 
     test('path from infer then toString', () => {

--- a/src/Rotorise.spec.ts
+++ b/src/Rotorise.spec.ts
@@ -208,7 +208,7 @@ describe('DynamoDB Utils', () => {
                   >
               >
 
-        attest.instantiations([5780, 'instantiations'])
+        attest.instantiations([5778, 'instantiations'])
     })
 
     it('tableEntry', () => {
@@ -729,7 +729,7 @@ describe('DynamoDB Utils', () => {
             }),
         ).toBeUndefined()
 
-        attest.instantiations([61232, 'instantiations'])
+        attest.instantiations([61230, 'instantiations'])
     })
 
     test('real world example', () => {

--- a/src/Rotorise.spec.ts
+++ b/src/Rotorise.spec.ts
@@ -57,7 +57,7 @@ describe('DynamoDB Utils', () => {
                   >
               >
 
-        attest.instantiations([1924, 'instantiations'])
+        attest.instantiations([1721, 'instantiations'])
     })
 
     it('CompositeKeyBuilder', () => {
@@ -377,7 +377,7 @@ describe('DynamoDB Utils', () => {
             ),
         ).toBe(1)
 
-        attest.instantiations([11700, 'instantiations'])
+        attest.instantiations([10981, 'instantiations'])
     })
 
     test('path from infer then toString', () => {
@@ -729,7 +729,7 @@ describe('DynamoDB Utils', () => {
             }),
         ).toBeUndefined()
 
-        attest.instantiations([64583, 'instantiations'])
+        attest.instantiations([63523, 'instantiations'])
     })
 
     test('real world example', () => {
@@ -945,7 +945,7 @@ describe('DynamoDB Utils', () => {
             { depth: 2 },
         ) satisfies 'TAG#A#ID2#yolo'
 
-        attest.instantiations([35984, 'instantiations'])
+        attest.instantiations([33275, 'instantiations'])
     })
 
     test('schema allows for nullish values if has transform', () => {

--- a/src/Rotorise.spec.ts
+++ b/src/Rotorise.spec.ts
@@ -19,43 +19,43 @@ describe('DynamoDB Utils', () => {
     it('CompositeKeyParams', () => {
         type test_CompositeKeyParams =
             | isTrue<
-                Equal<
-                    CompositeKeyParams<
-                        { a: string; b: number; c: boolean },
-                        ['a', 'b', 'c']
-                    >,
-                    { a: string; b?: number; c?: boolean }
-                >
-            >
+                  Equal<
+                      CompositeKeyParams<
+                          { a: string; b: number; c: boolean },
+                          ['a', 'b', 'c']
+                      >,
+                      { a: string; b?: number; c?: boolean }
+                  >
+              >
             | isTrue<
-                Equal<
-                    CompositeKeyParams<
-                        { a: string; b: number; c: boolean },
-                        ['a', 'b', ['c', (c: boolean) => 'TRANSFORM']]
-                    >,
-                    { a: string; b?: number; c?: boolean }
-                >
-            >
+                  Equal<
+                      CompositeKeyParams<
+                          { a: string; b: number; c: boolean },
+                          ['a', 'b', ['c', (c: boolean) => 'TRANSFORM']]
+                      >,
+                      { a: string; b?: number; c?: boolean }
+                  >
+              >
             | isTrue<
-                Equal<
-                    CompositeKeyParams<
-                        { a: string; b: number; c: boolean },
-                        ['a', 'b', ['c', (c: boolean) => 'TRANSFORM']],
-                        2
-                    >,
-                    { a: string; b: number; c?: boolean }
-                >
-            >
+                  Equal<
+                      CompositeKeyParams<
+                          { a: string; b: number; c: boolean },
+                          ['a', 'b', ['c', (c: boolean) => 'TRANSFORM']],
+                          2
+                      >,
+                      { a: string; b: number; c?: boolean }
+                  >
+              >
             | isTrue<
-                Equal<
-                    CompositeKeyParams<
-                        { a: string; b: number; c: boolean },
-                        ['a', 'b', ['c', (c: boolean) => 'TRANSFORM']],
-                        number
-                    >,
-                    { a: string; b?: number; c?: boolean }
-                >
-            >
+                  Equal<
+                      CompositeKeyParams<
+                          { a: string; b: number; c: boolean },
+                          ['a', 'b', ['c', (c: boolean) => 'TRANSFORM']],
+                          number
+                      >,
+                      { a: string; b?: number; c?: boolean }
+                  >
+              >
 
         attest.instantiations([1924, 'instantiations'])
     })
@@ -63,150 +63,150 @@ describe('DynamoDB Utils', () => {
     it('CompositeKeyBuilder', () => {
         type test_CompositeKeyBuilder =
             | isTrue<
-                Equal<
-                    CompositeKeyBuilder<
-                        { a: string; b: number; c: boolean },
-                        ['a', 'b', 'c']
-                    >,
-                    `A#${string}#B#${number}#C#${boolean}`
-                >
-            >
+                  Equal<
+                      CompositeKeyBuilder<
+                          { a: string; b: number; c: boolean },
+                          ['a', 'b', 'c']
+                      >,
+                      `A#${string}#B#${number}#C#${boolean}`
+                  >
+              >
             | isTrue<
-                Equal<
-                    CompositeKeyBuilder<
-                        | { a: 'a1'; b: 1; c: true; z: never }
-                        | { a: 'a2'; b: 2; c: true; z: never },
-                        ['a', 'b']
-                    >,
-                    `A#${'a1'}#B#${1}` | `A#${'a2'}#B#${2}`
-                >
-            >
+                  Equal<
+                      CompositeKeyBuilder<
+                          | { a: 'a1'; b: 1; c: true; z: never }
+                          | { a: 'a2'; b: 2; c: true; z: never },
+                          ['a', 'b']
+                      >,
+                      `A#${'a1'}#B#${1}` | `A#${'a2'}#B#${2}`
+                  >
+              >
             | isTrue<
-                Equal<
-                    CompositeKeyBuilder<
-                        { a: string; b: number; c: boolean },
-                        ['a', 'b', 'c'],
-                        '-'
-                    >,
-                    `A-${string}-B-${number}-C-${boolean}`
-                >
-            >
+                  Equal<
+                      CompositeKeyBuilder<
+                          { a: string; b: number; c: boolean },
+                          ['a', 'b', 'c'],
+                          '-'
+                      >,
+                      `A-${string}-B-${number}-C-${boolean}`
+                  >
+              >
             | isTrue<
-                Equal<
-                    CompositeKeyBuilder<
-                        { a: string; b: number; c: boolean },
-                        ['a', 'b', 'c'],
-                        '-',
-                        2
-                    >,
-                    `A-${string}-B-${number}`
-                >
-            >
+                  Equal<
+                      CompositeKeyBuilder<
+                          { a: string; b: number; c: boolean },
+                          ['a', 'b', 'c'],
+                          '-',
+                          2
+                      >,
+                      `A-${string}-B-${number}`
+                  >
+              >
             | isTrue<
-                Equal<
-                    CompositeKeyBuilder<
-                        { a: string; b: number; c: boolean },
-                        ['a', 'b', 'c'],
-                        '-',
-                        3,
-                        true
-                    >,
-                    | `A-${string}`
-                    | `A-${string}-B-${number}`
-                    | `A-${string}-B-${number}-C-${boolean}`
-                >
-            >
+                  Equal<
+                      CompositeKeyBuilder<
+                          { a: string; b: number; c: boolean },
+                          ['a', 'b', 'c'],
+                          '-',
+                          3,
+                          true
+                      >,
+                      | `A-${string}`
+                      | `A-${string}-B-${number}`
+                      | `A-${string}-B-${number}-C-${boolean}`
+                  >
+              >
             | isTrue<
-                Equal<
-                    CompositeKeyBuilder<
-                        | { a: 'a1'; b: 1; c: true; z: never }
-                        | { a: 'a2'; b: 2; c: false; z: never },
-                        ['a', 'b', 'c'],
-                        '#',
-                        3,
-                        true
-                    >,
-                    | 'A#a1'
-                    | 'A#a1#B#1'
-                    | 'A#a1#B#1#C#true'
-                    | 'A#a2'
-                    | 'A#a2#B#2'
-                    | 'A#a2#B#2#C#false'
-                >
-            >
+                  Equal<
+                      CompositeKeyBuilder<
+                          | { a: 'a1'; b: 1; c: true; z: never }
+                          | { a: 'a2'; b: 2; c: false; z: never },
+                          ['a', 'b', 'c'],
+                          '#',
+                          3,
+                          true
+                      >,
+                      | 'A#a1'
+                      | 'A#a1#B#1'
+                      | 'A#a1#B#1#C#true'
+                      | 'A#a2'
+                      | 'A#a2#B#2'
+                      | 'A#a2#B#2#C#false'
+                  >
+              >
             | isTrue<
-                Equal<
-                    CompositeKeyBuilder<
-                        | { a: 'a1'; b: 1; c: true; z: never }
-                        | { a: 'a2'; b: 2; c: false; z: never },
-                        ['a', 'b', ['c', (c: boolean) => 'TRANSFORM']],
-                        '#',
-                        3,
-                        true
-                    >,
-                    | 'A#a1'
-                    | 'A#a1#B#1'
-                    | 'A#a2'
-                    | 'A#a2#B#2'
-                    | 'A#a1#B#1#C#TRANSFORM'
-                    | 'A#a2#B#2#C#TRANSFORM'
-                >
-            >
+                  Equal<
+                      CompositeKeyBuilder<
+                          | { a: 'a1'; b: 1; c: true; z: never }
+                          | { a: 'a2'; b: 2; c: false; z: never },
+                          ['a', 'b', ['c', (c: boolean) => 'TRANSFORM']],
+                          '#',
+                          3,
+                          true
+                      >,
+                      | 'A#a1'
+                      | 'A#a1#B#1'
+                      | 'A#a2'
+                      | 'A#a2#B#2'
+                      | 'A#a1#B#1#C#TRANSFORM'
+                      | 'A#a2#B#2#C#TRANSFORM'
+                  >
+              >
             | isTrue<
-                Equal<
-                    CompositeKeyBuilder<
-                        | { a: 'a1'; b: 1; c: true; z: never }
-                        | { a: 'a2'; b: 2; c: false; z: never },
-                        [
-                            'a',
-                            'b',
-                            [
-                                'c',
-                                (c: boolean) => {
-                                    tag: 'TAG'
-                                    value: 'TRANSFORM'
-                                },
-                            ],
-                        ],
-                        '#',
-                        3,
-                        true
-                    >,
-                    | 'A#a1'
-                    | 'A#a1#B#1'
-                    | 'A#a2'
-                    | 'A#a2#B#2'
-                    | 'A#a1#B#1#TAG#TRANSFORM'
-                    | 'A#a2#B#2#TAG#TRANSFORM'
-                >
-            >
+                  Equal<
+                      CompositeKeyBuilder<
+                          | { a: 'a1'; b: 1; c: true; z: never }
+                          | { a: 'a2'; b: 2; c: false; z: never },
+                          [
+                              'a',
+                              'b',
+                              [
+                                  'c',
+                                  (c: boolean) => {
+                                      tag: 'TAG'
+                                      value: 'TRANSFORM'
+                                  },
+                              ],
+                          ],
+                          '#',
+                          3,
+                          true
+                      >,
+                      | 'A#a1'
+                      | 'A#a1#B#1'
+                      | 'A#a2'
+                      | 'A#a2#B#2'
+                      | 'A#a1#B#1#TAG#TRANSFORM'
+                      | 'A#a2#B#2#TAG#TRANSFORM'
+                  >
+              >
             | isTrue<
-                Equal<
-                    CompositeKeyBuilder<
-                        | { a: 'a1'; b: 1; c: true; z: never }
-                        | { a: 'a2'; b: 2; c: false; z: never },
-                        [
-                            'a',
-                            'b',
-                            [
-                                'c',
-                                (c: boolean) => {
-                                    value: 'TRANSFORM'
-                                },
-                            ],
-                        ],
-                        '#',
-                        3,
-                        true
-                    >,
-                    | 'A#a1'
-                    | 'A#a1#B#1'
-                    | 'A#a2'
-                    | 'A#a2#B#2'
-                    | 'A#a1#B#1#TRANSFORM'
-                    | 'A#a2#B#2#TRANSFORM'
-                >
-            >
+                  Equal<
+                      CompositeKeyBuilder<
+                          | { a: 'a1'; b: 1; c: true; z: never }
+                          | { a: 'a2'; b: 2; c: false; z: never },
+                          [
+                              'a',
+                              'b',
+                              [
+                                  'c',
+                                  (c: boolean) => {
+                                      value: 'TRANSFORM'
+                                  },
+                              ],
+                          ],
+                          '#',
+                          3,
+                          true
+                      >,
+                      | 'A#a1'
+                      | 'A#a1#B#1'
+                      | 'A#a2'
+                      | 'A#a2#B#2'
+                      | 'A#a1#B#1#TRANSFORM'
+                      | 'A#a2#B#2#TRANSFORM'
+                  >
+              >
 
         attest.instantiations([5780, 'instantiations'])
     })
@@ -230,23 +230,23 @@ describe('DynamoDB Utils', () => {
 
         type entries =
             | ({
-                a: 'a1'
-                b: 1
-                c: true
-                z: 'never'
-            } & {
-                readonly PK: 'A-a1-B-1-C-true'
-                readonly SK: 1
-            })
+                  a: 'a1'
+                  b: 1
+                  c: true
+                  z: 'never'
+              } & {
+                  readonly PK: 'A-a1-B-1-C-true'
+                  readonly SK: 1
+              })
             | ({
-                a: 'a2'
-                b: 2
-                c: true
-                z: 'never'
-            } & {
-                readonly PK: 'A-a2-B-2-C-true'
-                readonly SK: 2
-            })
+                  a: 'a2'
+                  b: 2
+                  c: true
+                  z: 'never'
+              } & {
+                  readonly PK: 'A-a2-B-2-C-true'
+                  readonly SK: 2
+              })
 
         attest<entries>(testTableEntry.infer)
 
@@ -439,113 +439,113 @@ describe('DynamoDB Utils', () => {
                         | 'c'
                         | 'z'
                         | NonEmptyArray<
-                            | 'a'
-                            | 'b'
-                            | 'c'
-                            | 'z'
-                            | ['a', (key: 'a1' | 'a2') => TransformShape]
-                            | ['b', (key: 1n | 2) => TransformShape]
-                            | ['c', (key: true | 0) => TransformShape]
-                            | ['z', (key: 'never') => TransformShape]
-                        >
+                              | 'a'
+                              | 'b'
+                              | 'c'
+                              | 'z'
+                              | ['a', (key: 'a1' | 'a2') => TransformShape]
+                              | ['b', (key: 1n | 2) => TransformShape]
+                              | ['c', (key: true | 0) => TransformShape]
+                              | ['z', (key: 'never') => TransformShape]
+                          >
                         | null
                         | {
-                            discriminator: 'a'
-                            spec: {
-                                a1:
-                                | 'a'
-                                | 'b'
-                                | 'c'
-                                | 'z'
-                                | NonEmptyArray<
-                                    | 'a'
-                                    | 'b'
-                                    | 'c'
-                                    | 'z'
-                                    | [
-                                        'a',
-                                        (key: 'a1') => TransformShape,
-                                    ]
-                                    | ['b', (key: 1n) => TransformShape]
-                                    | [
-                                        'c',
-                                        (key: true) => TransformShape,
-                                    ]
-                                    | [
-                                        'z',
-                                        (
-                                            key: 'never',
-                                        ) => TransformShape,
-                                    ]
-                                >
-                                | null
-                                a2:
-                                | 'a'
-                                | 'b'
-                                | 'c'
-                                | 'z'
-                                | NonEmptyArray<
-                                    | 'a'
-                                    | 'b'
-                                    | 'c'
-                                    | 'z'
-                                    | [
-                                        'a',
-                                        (key: 'a2') => TransformShape,
-                                    ]
-                                    | ['b', (key: 2) => TransformShape]
-                                    | ['c', (key: 0) => TransformShape]
-                                    | [
-                                        'z',
-                                        (
-                                            key: 'never',
-                                        ) => TransformShape,
-                                    ]
-                                >
-                                | null
-                            }
-                        }
+                              discriminator: 'a'
+                              spec: {
+                                  a1:
+                                      | 'a'
+                                      | 'b'
+                                      | 'c'
+                                      | 'z'
+                                      | NonEmptyArray<
+                                            | 'a'
+                                            | 'b'
+                                            | 'c'
+                                            | 'z'
+                                            | [
+                                                  'a',
+                                                  (key: 'a1') => TransformShape,
+                                              ]
+                                            | ['b', (key: 1n) => TransformShape]
+                                            | [
+                                                  'c',
+                                                  (key: true) => TransformShape,
+                                              ]
+                                            | [
+                                                  'z',
+                                                  (
+                                                      key: 'never',
+                                                  ) => TransformShape,
+                                              ]
+                                        >
+                                      | null
+                                  a2:
+                                      | 'a'
+                                      | 'b'
+                                      | 'c'
+                                      | 'z'
+                                      | NonEmptyArray<
+                                            | 'a'
+                                            | 'b'
+                                            | 'c'
+                                            | 'z'
+                                            | [
+                                                  'a',
+                                                  (key: 'a2') => TransformShape,
+                                              ]
+                                            | ['b', (key: 2) => TransformShape]
+                                            | ['c', (key: 0) => TransformShape]
+                                            | [
+                                                  'z',
+                                                  (
+                                                      key: 'never',
+                                                  ) => TransformShape,
+                                              ]
+                                        >
+                                      | null
+                              }
+                          }
                         | {
-                            discriminator: 'z'
-                            spec: {
-                                never:
-                                | 'a'
-                                | 'b'
-                                | 'c'
-                                | 'z'
-                                | NonEmptyArray<
-                                    | 'a'
-                                    | 'b'
-                                    | 'c'
-                                    | 'z'
-                                    | [
-                                        'a',
-                                        (
-                                            key: 'a1' | 'a2',
-                                        ) => TransformShape,
-                                    ]
-                                    | [
-                                        'b',
-                                        (
-                                            key: 2 | 1n,
-                                        ) => TransformShape,
-                                    ]
-                                    | [
-                                        'c',
-                                        (
-                                            key: true | 0,
-                                        ) => TransformShape,
-                                    ]
-                                    | [
-                                        'z',
-                                        (
-                                            key: 'never',
-                                        ) => TransformShape,
-                                    ]
-                                >
-                                | null
-                            }
-                        }
+                              discriminator: 'z'
+                              spec: {
+                                  never:
+                                      | 'a'
+                                      | 'b'
+                                      | 'c'
+                                      | 'z'
+                                      | NonEmptyArray<
+                                            | 'a'
+                                            | 'b'
+                                            | 'c'
+                                            | 'z'
+                                            | [
+                                                  'a',
+                                                  (
+                                                      key: 'a1' | 'a2',
+                                                  ) => TransformShape,
+                                              ]
+                                            | [
+                                                  'b',
+                                                  (
+                                                      key: 2 | 1n,
+                                                  ) => TransformShape,
+                                              ]
+                                            | [
+                                                  'c',
+                                                  (
+                                                      key: true | 0,
+                                                  ) => TransformShape,
+                                              ]
+                                            | [
+                                                  'z',
+                                                  (
+                                                      key: 'never',
+                                                  ) => TransformShape,
+                                              ]
+                                        >
+                                      | null
+                              }
+                          }
                     >,
                     separator?: string | undefined,
                 ]
@@ -602,31 +602,31 @@ describe('DynamoDB Utils', () => {
 
         type entries =
             | ({
-                a: 'a1'
-                b: 1n
-                c: true
-                z: 'never'
-            } & {
-                readonly PK: 'A-a1-B-1-C-VERDADERO' | 'A-a1-B-1-C-FALSO'
-                readonly SK: 1n
-                readonly GSI1PK: 1n
-                readonly GSI1SK:
-                | 'A-a1-B-1-NEW_TAG-VERDADERO'
-                | 'A-a1-B-1-NEW_TAG-FALSO'
-                readonly GSI2PK: never
-            })
+                  a: 'a1'
+                  b: 1n
+                  c: true
+                  z: 'never'
+              } & {
+                  readonly PK: 'A-a1-B-1-C-VERDADERO' | 'A-a1-B-1-C-FALSO'
+                  readonly SK: 1n
+                  readonly GSI1PK: 1n
+                  readonly GSI1SK:
+                      | 'A-a1-B-1-NEW_TAG-VERDADERO'
+                      | 'A-a1-B-1-NEW_TAG-FALSO'
+                  readonly GSI2PK: never
+              })
             | ({
-                a: 'a2'
-                b: 2
-                c: 0
-                z: 'never'
-            } & {
-                readonly PK: 'A-a2-B-2-C-VERDADERO' | 'A-a2-B-2-C-FALSO'
-                readonly SK: 2
-                readonly GSI1PK: 2
-                readonly GSI1SK: 2
-                readonly GSI2PK: 2
-            })
+                  a: 'a2'
+                  b: 2
+                  c: 0
+                  z: 'never'
+              } & {
+                  readonly PK: 'A-a2-B-2-C-VERDADERO' | 'A-a2-B-2-C-FALSO'
+                  readonly SK: 2
+                  readonly GSI1PK: 2
+                  readonly GSI1SK: 2
+                  readonly GSI2PK: 2
+              })
 
         type expect_infer = isTrue<Equal<typeof testTableEntry.infer, entries>>
 
@@ -854,29 +854,29 @@ describe('DynamoDB Utils', () => {
             Equal<
                 RealEntry,
                 | (A & {
-                    readonly PK: `ID1#${string}#USER#${string}`
-                    readonly SK: `TAG#A#ID2#${string}#TYPE#TypeA`
-                    readonly GSI1PK: `ID2#${string}`
-                    readonly GSI1SK: `TYPE#TypeA`
-                })
+                      readonly PK: `ID1#${string}#USER#${string}`
+                      readonly SK: `TAG#A#ID2#${string}#TYPE#TypeA`
+                      readonly GSI1PK: `ID2#${string}`
+                      readonly GSI1SK: `TYPE#TypeA`
+                  })
                 | ({
-                    readonly PK: `ID1#${string}#USER#${string}`
-                    readonly SK: `TAG#C#ID2#${string}#TYPE#TypeB`
-                    readonly GSI1PK: `ID2#${string}`
-                    readonly GSI1SK: `TYPE#TypeB`
-                } & C)
+                      readonly PK: `ID1#${string}#USER#${string}`
+                      readonly SK: `TAG#C#ID2#${string}#TYPE#TypeB`
+                      readonly GSI1PK: `ID2#${string}`
+                      readonly GSI1SK: `TYPE#TypeB`
+                  } & C)
                 | ({
-                    readonly PK: `ID1#${string}#USER#${string}`
-                    readonly SK: `TAG#D#ID2#${string}#KIND#${string}#TYPE#TypeA`
-                    readonly GSI1PK: `ID2#${string}`
-                    readonly GSI1SK: `KIND#${string}`
-                } & D)
+                      readonly PK: `ID1#${string}#USER#${string}`
+                      readonly SK: `TAG#D#ID2#${string}#KIND#${string}#TYPE#TypeA`
+                      readonly GSI1PK: `ID2#${string}`
+                      readonly GSI1SK: `KIND#${string}`
+                  } & D)
                 | ({
-                    readonly PK: `ID1#${string}#USER#${string}`
-                    readonly SK: `TAG#B#ID2#${string}#TYPE#TypeB`
-                    readonly GSI1PK: `ID2#${string}`
-                    readonly GSI1SK: `TYPE#TypeB`
-                } & B)
+                      readonly PK: `ID1#${string}#USER#${string}`
+                      readonly SK: `TAG#B#ID2#${string}#TYPE#TypeB`
+                      readonly GSI1PK: `ID2#${string}`
+                      readonly GSI1SK: `TYPE#TypeB`
+                  } & B)
             >
         >
 
@@ -965,75 +965,75 @@ describe('DynamoDB Utils', () => {
                         | 'c'
                         | 'z'
                         | NonEmptyArray<
-                            | 'a'
-                            | 'b'
-                            | 'c'
-                            | ['a', (key: 'a1' | 'a2') => TransformShape]
-                            | ['b', (key: 1n | 2) => TransformShape]
-                            | ['c', (key: true | 0) => TransformShape]
-                            | [
-                                'z',
-                                (key: 'never' | null) => TransformShape,
-                                'never' | null,
-                            ]
-                        >
+                              | 'a'
+                              | 'b'
+                              | 'c'
+                              | ['a', (key: 'a1' | 'a2') => TransformShape]
+                              | ['b', (key: 1n | 2) => TransformShape]
+                              | ['c', (key: true | 0) => TransformShape]
+                              | [
+                                    'z',
+                                    (key: 'never' | null) => TransformShape,
+                                    'never' | null,
+                                ]
+                          >
                         | null
                         | {
-                            discriminator: 'a'
-                            spec: {
-                                a1:
-                                | 'a'
-                                | 'b'
-                                | 'c'
-                                | 'z'
-                                | NonEmptyArray<
-                                    | 'a'
-                                    | 'b'
-                                    | 'c'
-                                    | 'z'
-                                    | [
-                                        'a',
-                                        (key: 'a1') => TransformShape,
-                                    ]
-                                    | ['b', (key: 1n) => TransformShape]
-                                    | [
-                                        'c',
-                                        (key: true) => TransformShape,
-                                    ]
-                                    | [
-                                        'z',
-                                        (
-                                            key: 'never',
-                                        ) => TransformShape,
-                                    ]
-                                >
-                                | null
-                                a2:
-                                | 'a'
-                                | 'b'
-                                | 'c'
-                                | 'z'
-                                | NonEmptyArray<
-                                    | 'a'
-                                    | 'b'
-                                    | 'c'
-                                    | [
-                                        'a',
-                                        (key: 'a2') => TransformShape,
-                                    ]
-                                    | ['b', (key: 2) => TransformShape]
-                                    | ['c', (key: 0) => TransformShape]
-                                    | [
-                                        'z',
-                                        (
-                                            key: 'never' | null,
-                                        ) => TransformShape,
-                                        'never' | null,
-                                    ]
-                                >
-                                | null
-                            }
-                        }
+                              discriminator: 'a'
+                              spec: {
+                                  a1:
+                                      | 'a'
+                                      | 'b'
+                                      | 'c'
+                                      | 'z'
+                                      | NonEmptyArray<
+                                            | 'a'
+                                            | 'b'
+                                            | 'c'
+                                            | 'z'
+                                            | [
+                                                  'a',
+                                                  (key: 'a1') => TransformShape,
+                                              ]
+                                            | ['b', (key: 1n) => TransformShape]
+                                            | [
+                                                  'c',
+                                                  (key: true) => TransformShape,
+                                              ]
+                                            | [
+                                                  'z',
+                                                  (
+                                                      key: 'never',
+                                                  ) => TransformShape,
+                                              ]
+                                        >
+                                      | null
+                                  a2:
+                                      | 'a'
+                                      | 'b'
+                                      | 'c'
+                                      | 'z'
+                                      | NonEmptyArray<
+                                            | 'a'
+                                            | 'b'
+                                            | 'c'
+                                            | [
+                                                  'a',
+                                                  (key: 'a2') => TransformShape,
+                                              ]
+                                            | ['b', (key: 2) => TransformShape]
+                                            | ['c', (key: 0) => TransformShape]
+                                            | [
+                                                  'z',
+                                                  (
+                                                      key: 'never' | null,
+                                                  ) => TransformShape,
+                                                  'never' | null,
+                                              ]
+                                        >
+                                      | null
+                              }
+                          }
                     >,
                     separator?: string | undefined,
                 ]
@@ -1064,27 +1064,27 @@ describe('DynamoDB Utils', () => {
 
         type entries =
             | ({
-                a: 'a1'
-                b: 1n
-                c: true
-                z: 'never'
-            } & {
-                readonly PK: `A-a1-B-${string}-C-true`
-                readonly SK: 'C-true-Z-never' | 'C-true-Z-DEFAULT'
-                readonly GSIPK: 'never'
-                readonly GSISK: 'Z-never-Z-never'
-            })
+                  a: 'a1'
+                  b: 1n
+                  c: true
+                  z: 'never'
+              } & {
+                  readonly PK: `A-a1-B-${string}-C-true`
+                  readonly SK: 'C-true-Z-never' | 'C-true-Z-DEFAULT'
+                  readonly GSIPK: 'never'
+                  readonly GSISK: 'Z-never-Z-never'
+              })
             | ({
-                a: 'a2'
-                b: 2
-                c: 0
-                z?: 'never' | null
-            } & {
-                readonly PK: `A-a2-B-${string}-C-0`
-                readonly SK: 'C-0-Z-DEFAULT' | 'C-0-Z-never'
-                readonly GSIPK: 'never' | undefined
-                readonly GSISK: 'Z-never' | 'Z-DEFAULT'
-            })
+                  a: 'a2'
+                  b: 2
+                  c: 0
+                  z?: 'never' | null
+              } & {
+                  readonly PK: `A-a2-B-${string}-C-0`
+                  readonly SK: 'C-0-Z-DEFAULT' | 'C-0-Z-never'
+                  readonly GSIPK: 'never' | undefined
+                  readonly GSISK: 'Z-never' | 'Z-DEFAULT'
+              })
 
         type expect_infer = isTrue<Equal<typeof testTableEntry.infer, entries>>
 
@@ -1129,51 +1129,51 @@ describe('DynamoDB Utils', () => {
                         | 'a'
                         | 'b'
                         | NonEmptyArray<
-                            | 'a'
-                            | 'b'
-                            | ['a', (key: 'a1' | 'a2') => TransformShape]
-                            | ['b', (key: 1n | 2) => TransformShape]
-                        >
+                              | 'a'
+                              | 'b'
+                              | ['a', (key: 'a1' | 'a2') => TransformShape]
+                              | ['b', (key: 1n | 2) => TransformShape]
+                          >
                         | null
                         | {
-                            discriminator: 'a'
-                            spec: {
-                                a1:
-                                | 'a'
-                                | 'b'
-                                | 'extra'
-                                | NonEmptyArray<
-                                    | 'a'
-                                    | 'b'
-                                    | 'extra'
-                                    | [
-                                        'a',
-                                        (key: 'a1') => TransformShape,
-                                    ]
-                                    | ['b', (key: 1n) => TransformShape]
-                                    | [
-                                        'extra',
-                                        (
-                                            key: 'extra',
-                                        ) => TransformShape,
-                                    ]
-                                >
-                                | null
-                                a2:
-                                | 'a'
-                                | 'b'
-                                | NonEmptyArray<
-                                    | 'a'
-                                    | 'b'
-                                    | [
-                                        'a',
-                                        (key: 'a2') => TransformShape,
-                                    ]
-                                    | ['b', (key: 2) => TransformShape]
-                                >
-                                | null
-                            }
-                        }
+                              discriminator: 'a'
+                              spec: {
+                                  a1:
+                                      | 'a'
+                                      | 'b'
+                                      | 'extra'
+                                      | NonEmptyArray<
+                                            | 'a'
+                                            | 'b'
+                                            | 'extra'
+                                            | [
+                                                  'a',
+                                                  (key: 'a1') => TransformShape,
+                                              ]
+                                            | ['b', (key: 1n) => TransformShape]
+                                            | [
+                                                  'extra',
+                                                  (
+                                                      key: 'extra',
+                                                  ) => TransformShape,
+                                              ]
+                                        >
+                                      | null
+                                  a2:
+                                      | 'a'
+                                      | 'b'
+                                      | NonEmptyArray<
+                                            | 'a'
+                                            | 'b'
+                                            | [
+                                                  'a',
+                                                  (key: 'a2') => TransformShape,
+                                              ]
+                                            | ['b', (key: 2) => TransformShape]
+                                        >
+                                      | null
+                              }
+                          }
                     >,
                     separator?: string | undefined,
                 ]

--- a/src/Rotorise.spec.ts
+++ b/src/Rotorise.spec.ts
@@ -19,196 +19,196 @@ describe('DynamoDB Utils', () => {
     it('CompositeKeyParams', () => {
         type test_CompositeKeyParams =
             | isTrue<
-                  Equal<
-                      CompositeKeyParams<
-                          { a: string; b: number; c: boolean },
-                          ['a', 'b', 'c']
-                      >,
-                      { a: string; b?: number; c?: boolean }
-                  >
-              >
+                Equal<
+                    CompositeKeyParams<
+                        { a: string; b: number; c: boolean },
+                        ['a', 'b', 'c']
+                    >,
+                    { a: string; b?: number; c?: boolean }
+                >
+            >
             | isTrue<
-                  Equal<
-                      CompositeKeyParams<
-                          { a: string; b: number; c: boolean },
-                          ['a', 'b', ['c', (c: boolean) => 'TRANSFORM']]
-                      >,
-                      { a: string; b?: number; c?: boolean }
-                  >
-              >
+                Equal<
+                    CompositeKeyParams<
+                        { a: string; b: number; c: boolean },
+                        ['a', 'b', ['c', (c: boolean) => 'TRANSFORM']]
+                    >,
+                    { a: string; b?: number; c?: boolean }
+                >
+            >
             | isTrue<
-                  Equal<
-                      CompositeKeyParams<
-                          { a: string; b: number; c: boolean },
-                          ['a', 'b', ['c', (c: boolean) => 'TRANSFORM']],
-                          2
-                      >,
-                      { a: string; b: number; c?: boolean }
-                  >
-              >
+                Equal<
+                    CompositeKeyParams<
+                        { a: string; b: number; c: boolean },
+                        ['a', 'b', ['c', (c: boolean) => 'TRANSFORM']],
+                        2
+                    >,
+                    { a: string; b: number; c?: boolean }
+                >
+            >
             | isTrue<
-                  Equal<
-                      CompositeKeyParams<
-                          { a: string; b: number; c: boolean },
-                          ['a', 'b', ['c', (c: boolean) => 'TRANSFORM']],
-                          number
-                      >,
-                      { a: string; b?: number; c?: boolean }
-                  >
-              >
+                Equal<
+                    CompositeKeyParams<
+                        { a: string; b: number; c: boolean },
+                        ['a', 'b', ['c', (c: boolean) => 'TRANSFORM']],
+                        number
+                    >,
+                    { a: string; b?: number; c?: boolean }
+                >
+            >
 
-        attest.instantiations([2012, 'instantiations'])
+        attest.instantiations([1924, 'instantiations'])
     })
 
     it('CompositeKeyBuilder', () => {
         type test_CompositeKeyBuilder =
             | isTrue<
-                  Equal<
-                      CompositeKeyBuilder<
-                          { a: string; b: number; c: boolean },
-                          ['a', 'b', 'c']
-                      >,
-                      `A#${string}#B#${number}#C#${boolean}`
-                  >
-              >
+                Equal<
+                    CompositeKeyBuilder<
+                        { a: string; b: number; c: boolean },
+                        ['a', 'b', 'c']
+                    >,
+                    `A#${string}#B#${number}#C#${boolean}`
+                >
+            >
             | isTrue<
-                  Equal<
-                      CompositeKeyBuilder<
-                          | { a: 'a1'; b: 1; c: true; z: never }
-                          | { a: 'a2'; b: 2; c: true; z: never },
-                          ['a', 'b']
-                      >,
-                      `A#${'a1'}#B#${1}` | `A#${'a2'}#B#${2}`
-                  >
-              >
+                Equal<
+                    CompositeKeyBuilder<
+                        | { a: 'a1'; b: 1; c: true; z: never }
+                        | { a: 'a2'; b: 2; c: true; z: never },
+                        ['a', 'b']
+                    >,
+                    `A#${'a1'}#B#${1}` | `A#${'a2'}#B#${2}`
+                >
+            >
             | isTrue<
-                  Equal<
-                      CompositeKeyBuilder<
-                          { a: string; b: number; c: boolean },
-                          ['a', 'b', 'c'],
-                          '-'
-                      >,
-                      `A-${string}-B-${number}-C-${boolean}`
-                  >
-              >
+                Equal<
+                    CompositeKeyBuilder<
+                        { a: string; b: number; c: boolean },
+                        ['a', 'b', 'c'],
+                        '-'
+                    >,
+                    `A-${string}-B-${number}-C-${boolean}`
+                >
+            >
             | isTrue<
-                  Equal<
-                      CompositeKeyBuilder<
-                          { a: string; b: number; c: boolean },
-                          ['a', 'b', 'c'],
-                          '-',
-                          2
-                      >,
-                      `A-${string}-B-${number}`
-                  >
-              >
+                Equal<
+                    CompositeKeyBuilder<
+                        { a: string; b: number; c: boolean },
+                        ['a', 'b', 'c'],
+                        '-',
+                        2
+                    >,
+                    `A-${string}-B-${number}`
+                >
+            >
             | isTrue<
-                  Equal<
-                      CompositeKeyBuilder<
-                          { a: string; b: number; c: boolean },
-                          ['a', 'b', 'c'],
-                          '-',
-                          3,
-                          true
-                      >,
-                      | `A-${string}`
-                      | `A-${string}-B-${number}`
-                      | `A-${string}-B-${number}-C-${boolean}`
-                  >
-              >
+                Equal<
+                    CompositeKeyBuilder<
+                        { a: string; b: number; c: boolean },
+                        ['a', 'b', 'c'],
+                        '-',
+                        3,
+                        true
+                    >,
+                    | `A-${string}`
+                    | `A-${string}-B-${number}`
+                    | `A-${string}-B-${number}-C-${boolean}`
+                >
+            >
             | isTrue<
-                  Equal<
-                      CompositeKeyBuilder<
-                          | { a: 'a1'; b: 1; c: true; z: never }
-                          | { a: 'a2'; b: 2; c: false; z: never },
-                          ['a', 'b', 'c'],
-                          '#',
-                          3,
-                          true
-                      >,
-                      | 'A#a1'
-                      | 'A#a1#B#1'
-                      | 'A#a1#B#1#C#true'
-                      | 'A#a2'
-                      | 'A#a2#B#2'
-                      | 'A#a2#B#2#C#false'
-                  >
-              >
+                Equal<
+                    CompositeKeyBuilder<
+                        | { a: 'a1'; b: 1; c: true; z: never }
+                        | { a: 'a2'; b: 2; c: false; z: never },
+                        ['a', 'b', 'c'],
+                        '#',
+                        3,
+                        true
+                    >,
+                    | 'A#a1'
+                    | 'A#a1#B#1'
+                    | 'A#a1#B#1#C#true'
+                    | 'A#a2'
+                    | 'A#a2#B#2'
+                    | 'A#a2#B#2#C#false'
+                >
+            >
             | isTrue<
-                  Equal<
-                      CompositeKeyBuilder<
-                          | { a: 'a1'; b: 1; c: true; z: never }
-                          | { a: 'a2'; b: 2; c: false; z: never },
-                          ['a', 'b', ['c', (c: boolean) => 'TRANSFORM']],
-                          '#',
-                          3,
-                          true
-                      >,
-                      | 'A#a1'
-                      | 'A#a1#B#1'
-                      | 'A#a2'
-                      | 'A#a2#B#2'
-                      | 'A#a1#B#1#C#TRANSFORM'
-                      | 'A#a2#B#2#C#TRANSFORM'
-                  >
-              >
+                Equal<
+                    CompositeKeyBuilder<
+                        | { a: 'a1'; b: 1; c: true; z: never }
+                        | { a: 'a2'; b: 2; c: false; z: never },
+                        ['a', 'b', ['c', (c: boolean) => 'TRANSFORM']],
+                        '#',
+                        3,
+                        true
+                    >,
+                    | 'A#a1'
+                    | 'A#a1#B#1'
+                    | 'A#a2'
+                    | 'A#a2#B#2'
+                    | 'A#a1#B#1#C#TRANSFORM'
+                    | 'A#a2#B#2#C#TRANSFORM'
+                >
+            >
             | isTrue<
-                  Equal<
-                      CompositeKeyBuilder<
-                          | { a: 'a1'; b: 1; c: true; z: never }
-                          | { a: 'a2'; b: 2; c: false; z: never },
-                          [
-                              'a',
-                              'b',
-                              [
-                                  'c',
-                                  (c: boolean) => {
-                                      tag: 'TAG'
-                                      value: 'TRANSFORM'
-                                  },
-                              ],
-                          ],
-                          '#',
-                          3,
-                          true
-                      >,
-                      | 'A#a1'
-                      | 'A#a1#B#1'
-                      | 'A#a2'
-                      | 'A#a2#B#2'
-                      | 'A#a1#B#1#TAG#TRANSFORM'
-                      | 'A#a2#B#2#TAG#TRANSFORM'
-                  >
-              >
+                Equal<
+                    CompositeKeyBuilder<
+                        | { a: 'a1'; b: 1; c: true; z: never }
+                        | { a: 'a2'; b: 2; c: false; z: never },
+                        [
+                            'a',
+                            'b',
+                            [
+                                'c',
+                                (c: boolean) => {
+                                    tag: 'TAG'
+                                    value: 'TRANSFORM'
+                                },
+                            ],
+                        ],
+                        '#',
+                        3,
+                        true
+                    >,
+                    | 'A#a1'
+                    | 'A#a1#B#1'
+                    | 'A#a2'
+                    | 'A#a2#B#2'
+                    | 'A#a1#B#1#TAG#TRANSFORM'
+                    | 'A#a2#B#2#TAG#TRANSFORM'
+                >
+            >
             | isTrue<
-                  Equal<
-                      CompositeKeyBuilder<
-                          | { a: 'a1'; b: 1; c: true; z: never }
-                          | { a: 'a2'; b: 2; c: false; z: never },
-                          [
-                              'a',
-                              'b',
-                              [
-                                  'c',
-                                  (c: boolean) => {
-                                      value: 'TRANSFORM'
-                                  },
-                              ],
-                          ],
-                          '#',
-                          3,
-                          true
-                      >,
-                      | 'A#a1'
-                      | 'A#a1#B#1'
-                      | 'A#a2'
-                      | 'A#a2#B#2'
-                      | 'A#a1#B#1#TRANSFORM'
-                      | 'A#a2#B#2#TRANSFORM'
-                  >
-              >
+                Equal<
+                    CompositeKeyBuilder<
+                        | { a: 'a1'; b: 1; c: true; z: never }
+                        | { a: 'a2'; b: 2; c: false; z: never },
+                        [
+                            'a',
+                            'b',
+                            [
+                                'c',
+                                (c: boolean) => {
+                                    value: 'TRANSFORM'
+                                },
+                            ],
+                        ],
+                        '#',
+                        3,
+                        true
+                    >,
+                    | 'A#a1'
+                    | 'A#a1#B#1'
+                    | 'A#a2'
+                    | 'A#a2#B#2'
+                    | 'A#a1#B#1#TRANSFORM'
+                    | 'A#a2#B#2#TRANSFORM'
+                >
+            >
 
-        attest.instantiations([6653, 'instantiations'])
+        attest.instantiations([5780, 'instantiations'])
     })
 
     it('tableEntry', () => {
@@ -230,23 +230,23 @@ describe('DynamoDB Utils', () => {
 
         type entries =
             | ({
-                  a: 'a1'
-                  b: 1
-                  c: true
-                  z: 'never'
-              } & {
-                  readonly PK: 'A-a1-B-1-C-true'
-                  readonly SK: 1
-              })
+                a: 'a1'
+                b: 1
+                c: true
+                z: 'never'
+            } & {
+                readonly PK: 'A-a1-B-1-C-true'
+                readonly SK: 1
+            })
             | ({
-                  a: 'a2'
-                  b: 2
-                  c: true
-                  z: 'never'
-              } & {
-                  readonly PK: 'A-a2-B-2-C-true'
-                  readonly SK: 2
-              })
+                a: 'a2'
+                b: 2
+                c: true
+                z: 'never'
+            } & {
+                readonly PK: 'A-a2-B-2-C-true'
+                readonly SK: 2
+            })
 
         attest<entries>(testTableEntry.infer)
 
@@ -377,7 +377,7 @@ describe('DynamoDB Utils', () => {
             ),
         ).toBe(1)
 
-        attest.instantiations([11085, 'instantiations'])
+        attest.instantiations([11890, 'instantiations'])
     })
 
     test('path from infer then toString', () => {
@@ -413,7 +413,7 @@ describe('DynamoDB Utils', () => {
         )
         expect(testTableEntry.path().PK.toString()).toBe('PK')
 
-        attest.instantiations([1358, 'instantiations'])
+        attest.instantiations([1244, 'instantiations'])
     })
 
     test('table Entry with transform and discriminator ', () => {
@@ -439,113 +439,113 @@ describe('DynamoDB Utils', () => {
                         | 'c'
                         | 'z'
                         | NonEmptyArray<
-                              | 'a'
-                              | 'b'
-                              | 'c'
-                              | 'z'
-                              | ['a', (key: 'a1' | 'a2') => TransformShape]
-                              | ['b', (key: 1n | 2) => TransformShape]
-                              | ['c', (key: true | 0) => TransformShape]
-                              | ['z', (key: 'never') => TransformShape]
-                          >
+                            | 'a'
+                            | 'b'
+                            | 'c'
+                            | 'z'
+                            | ['a', (key: 'a1' | 'a2') => TransformShape]
+                            | ['b', (key: 1n | 2) => TransformShape]
+                            | ['c', (key: true | 0) => TransformShape]
+                            | ['z', (key: 'never') => TransformShape]
+                        >
                         | null
                         | {
-                              discriminator: 'a'
-                              spec: {
-                                  a1:
-                                      | 'a'
-                                      | 'b'
-                                      | 'c'
-                                      | 'z'
-                                      | NonEmptyArray<
-                                            | 'a'
-                                            | 'b'
-                                            | 'c'
-                                            | 'z'
-                                            | [
-                                                  'a',
-                                                  (key: 'a1') => TransformShape,
-                                              ]
-                                            | ['b', (key: 1n) => TransformShape]
-                                            | [
-                                                  'c',
-                                                  (key: true) => TransformShape,
-                                              ]
-                                            | [
-                                                  'z',
-                                                  (
-                                                      key: 'never',
-                                                  ) => TransformShape,
-                                              ]
-                                        >
-                                      | null
-                                  a2:
-                                      | 'a'
-                                      | 'b'
-                                      | 'c'
-                                      | 'z'
-                                      | NonEmptyArray<
-                                            | 'a'
-                                            | 'b'
-                                            | 'c'
-                                            | 'z'
-                                            | [
-                                                  'a',
-                                                  (key: 'a2') => TransformShape,
-                                              ]
-                                            | ['b', (key: 2) => TransformShape]
-                                            | ['c', (key: 0) => TransformShape]
-                                            | [
-                                                  'z',
-                                                  (
-                                                      key: 'never',
-                                                  ) => TransformShape,
-                                              ]
-                                        >
-                                      | null
-                              }
-                          }
+                            discriminator: 'a'
+                            spec: {
+                                a1:
+                                | 'a'
+                                | 'b'
+                                | 'c'
+                                | 'z'
+                                | NonEmptyArray<
+                                    | 'a'
+                                    | 'b'
+                                    | 'c'
+                                    | 'z'
+                                    | [
+                                        'a',
+                                        (key: 'a1') => TransformShape,
+                                    ]
+                                    | ['b', (key: 1n) => TransformShape]
+                                    | [
+                                        'c',
+                                        (key: true) => TransformShape,
+                                    ]
+                                    | [
+                                        'z',
+                                        (
+                                            key: 'never',
+                                        ) => TransformShape,
+                                    ]
+                                >
+                                | null
+                                a2:
+                                | 'a'
+                                | 'b'
+                                | 'c'
+                                | 'z'
+                                | NonEmptyArray<
+                                    | 'a'
+                                    | 'b'
+                                    | 'c'
+                                    | 'z'
+                                    | [
+                                        'a',
+                                        (key: 'a2') => TransformShape,
+                                    ]
+                                    | ['b', (key: 2) => TransformShape]
+                                    | ['c', (key: 0) => TransformShape]
+                                    | [
+                                        'z',
+                                        (
+                                            key: 'never',
+                                        ) => TransformShape,
+                                    ]
+                                >
+                                | null
+                            }
+                        }
                         | {
-                              discriminator: 'z'
-                              spec: {
-                                  never:
-                                      | 'a'
-                                      | 'b'
-                                      | 'c'
-                                      | 'z'
-                                      | NonEmptyArray<
-                                            | 'a'
-                                            | 'b'
-                                            | 'c'
-                                            | 'z'
-                                            | [
-                                                  'a',
-                                                  (
-                                                      key: 'a1' | 'a2',
-                                                  ) => TransformShape,
-                                              ]
-                                            | [
-                                                  'b',
-                                                  (
-                                                      key: 2 | 1n,
-                                                  ) => TransformShape,
-                                              ]
-                                            | [
-                                                  'c',
-                                                  (
-                                                      key: true | 0,
-                                                  ) => TransformShape,
-                                              ]
-                                            | [
-                                                  'z',
-                                                  (
-                                                      key: 'never',
-                                                  ) => TransformShape,
-                                              ]
-                                        >
-                                      | null
-                              }
-                          }
+                            discriminator: 'z'
+                            spec: {
+                                never:
+                                | 'a'
+                                | 'b'
+                                | 'c'
+                                | 'z'
+                                | NonEmptyArray<
+                                    | 'a'
+                                    | 'b'
+                                    | 'c'
+                                    | 'z'
+                                    | [
+                                        'a',
+                                        (
+                                            key: 'a1' | 'a2',
+                                        ) => TransformShape,
+                                    ]
+                                    | [
+                                        'b',
+                                        (
+                                            key: 2 | 1n,
+                                        ) => TransformShape,
+                                    ]
+                                    | [
+                                        'c',
+                                        (
+                                            key: true | 0,
+                                        ) => TransformShape,
+                                    ]
+                                    | [
+                                        'z',
+                                        (
+                                            key: 'never',
+                                        ) => TransformShape,
+                                    ]
+                                >
+                                | null
+                            }
+                        }
                     >,
                     separator?: string | undefined,
                 ]
@@ -602,31 +602,31 @@ describe('DynamoDB Utils', () => {
 
         type entries =
             | ({
-                  a: 'a1'
-                  b: 1n
-                  c: true
-                  z: 'never'
-              } & {
-                  readonly PK: 'A-a1-B-1-C-VERDADERO' | 'A-a1-B-1-C-FALSO'
-                  readonly SK: 1n
-                  readonly GSI1PK: 1n
-                  readonly GSI1SK:
-                      | 'A-a1-B-1-NEW_TAG-VERDADERO'
-                      | 'A-a1-B-1-NEW_TAG-FALSO'
-                  readonly GSI2PK: never
-              })
+                a: 'a1'
+                b: 1n
+                c: true
+                z: 'never'
+            } & {
+                readonly PK: 'A-a1-B-1-C-VERDADERO' | 'A-a1-B-1-C-FALSO'
+                readonly SK: 1n
+                readonly GSI1PK: 1n
+                readonly GSI1SK:
+                | 'A-a1-B-1-NEW_TAG-VERDADERO'
+                | 'A-a1-B-1-NEW_TAG-FALSO'
+                readonly GSI2PK: never
+            })
             | ({
-                  a: 'a2'
-                  b: 2
-                  c: 0
-                  z: 'never'
-              } & {
-                  readonly PK: 'A-a2-B-2-C-VERDADERO' | 'A-a2-B-2-C-FALSO'
-                  readonly SK: 2
-                  readonly GSI1PK: 2
-                  readonly GSI1SK: 2
-                  readonly GSI2PK: 2
-              })
+                a: 'a2'
+                b: 2
+                c: 0
+                z: 'never'
+            } & {
+                readonly PK: 'A-a2-B-2-C-VERDADERO' | 'A-a2-B-2-C-FALSO'
+                readonly SK: 2
+                readonly GSI1PK: 2
+                readonly GSI1SK: 2
+                readonly GSI2PK: 2
+            })
 
         type expect_infer = isTrue<Equal<typeof testTableEntry.infer, entries>>
 
@@ -729,7 +729,7 @@ describe('DynamoDB Utils', () => {
             }),
         ).toBeUndefined()
 
-        attest.instantiations([64827, 'instantiations'])
+        attest.instantiations([64942, 'instantiations'])
     })
 
     test('real world example', () => {
@@ -854,29 +854,29 @@ describe('DynamoDB Utils', () => {
             Equal<
                 RealEntry,
                 | (A & {
-                      readonly PK: `ID1#${string}#USER#${string}`
-                      readonly SK: `TAG#A#ID2#${string}#TYPE#TypeA`
-                      readonly GSI1PK: `ID2#${string}`
-                      readonly GSI1SK: `TYPE#TypeA`
-                  })
+                    readonly PK: `ID1#${string}#USER#${string}`
+                    readonly SK: `TAG#A#ID2#${string}#TYPE#TypeA`
+                    readonly GSI1PK: `ID2#${string}`
+                    readonly GSI1SK: `TYPE#TypeA`
+                })
                 | ({
-                      readonly PK: `ID1#${string}#USER#${string}`
-                      readonly SK: `TAG#C#ID2#${string}#TYPE#TypeB`
-                      readonly GSI1PK: `ID2#${string}`
-                      readonly GSI1SK: `TYPE#TypeB`
-                  } & C)
+                    readonly PK: `ID1#${string}#USER#${string}`
+                    readonly SK: `TAG#C#ID2#${string}#TYPE#TypeB`
+                    readonly GSI1PK: `ID2#${string}`
+                    readonly GSI1SK: `TYPE#TypeB`
+                } & C)
                 | ({
-                      readonly PK: `ID1#${string}#USER#${string}`
-                      readonly SK: `TAG#D#ID2#${string}#KIND#${string}#TYPE#TypeA`
-                      readonly GSI1PK: `ID2#${string}`
-                      readonly GSI1SK: `KIND#${string}`
-                  } & D)
+                    readonly PK: `ID1#${string}#USER#${string}`
+                    readonly SK: `TAG#D#ID2#${string}#KIND#${string}#TYPE#TypeA`
+                    readonly GSI1PK: `ID2#${string}`
+                    readonly GSI1SK: `KIND#${string}`
+                } & D)
                 | ({
-                      readonly PK: `ID1#${string}#USER#${string}`
-                      readonly SK: `TAG#B#ID2#${string}#TYPE#TypeB`
-                      readonly GSI1PK: `ID2#${string}`
-                      readonly GSI1SK: `TYPE#TypeB`
-                  } & B)
+                    readonly PK: `ID1#${string}#USER#${string}`
+                    readonly SK: `TAG#B#ID2#${string}#TYPE#TypeB`
+                    readonly GSI1PK: `ID2#${string}`
+                    readonly GSI1SK: `TYPE#TypeB`
+                } & B)
             >
         >
 
@@ -945,7 +945,7 @@ describe('DynamoDB Utils', () => {
             { depth: 2 },
         ) satisfies 'TAG#A#ID2#yolo'
 
-        attest.instantiations([38182, 'instantiations'])
+        attest.instantiations([36632, 'instantiations'])
     })
 
     test('schema allows for nullish values if has transform', () => {
@@ -965,75 +965,75 @@ describe('DynamoDB Utils', () => {
                         | 'c'
                         | 'z'
                         | NonEmptyArray<
-                              | 'a'
-                              | 'b'
-                              | 'c'
-                              | ['a', (key: 'a1' | 'a2') => TransformShape]
-                              | ['b', (key: 1n | 2) => TransformShape]
-                              | ['c', (key: true | 0) => TransformShape]
-                              | [
-                                    'z',
-                                    (key: 'never' | null) => TransformShape,
-                                    'never' | null,
-                                ]
-                          >
+                            | 'a'
+                            | 'b'
+                            | 'c'
+                            | ['a', (key: 'a1' | 'a2') => TransformShape]
+                            | ['b', (key: 1n | 2) => TransformShape]
+                            | ['c', (key: true | 0) => TransformShape]
+                            | [
+                                'z',
+                                (key: 'never' | null) => TransformShape,
+                                'never' | null,
+                            ]
+                        >
                         | null
                         | {
-                              discriminator: 'a'
-                              spec: {
-                                  a1:
-                                      | 'a'
-                                      | 'b'
-                                      | 'c'
-                                      | 'z'
-                                      | NonEmptyArray<
-                                            | 'a'
-                                            | 'b'
-                                            | 'c'
-                                            | 'z'
-                                            | [
-                                                  'a',
-                                                  (key: 'a1') => TransformShape,
-                                              ]
-                                            | ['b', (key: 1n) => TransformShape]
-                                            | [
-                                                  'c',
-                                                  (key: true) => TransformShape,
-                                              ]
-                                            | [
-                                                  'z',
-                                                  (
-                                                      key: 'never',
-                                                  ) => TransformShape,
-                                              ]
-                                        >
-                                      | null
-                                  a2:
-                                      | 'a'
-                                      | 'b'
-                                      | 'c'
-                                      | 'z'
-                                      | NonEmptyArray<
-                                            | 'a'
-                                            | 'b'
-                                            | 'c'
-                                            | [
-                                                  'a',
-                                                  (key: 'a2') => TransformShape,
-                                              ]
-                                            | ['b', (key: 2) => TransformShape]
-                                            | ['c', (key: 0) => TransformShape]
-                                            | [
-                                                  'z',
-                                                  (
-                                                      key: 'never' | null,
-                                                  ) => TransformShape,
-                                                  'never' | null,
-                                              ]
-                                        >
-                                      | null
-                              }
-                          }
+                            discriminator: 'a'
+                            spec: {
+                                a1:
+                                | 'a'
+                                | 'b'
+                                | 'c'
+                                | 'z'
+                                | NonEmptyArray<
+                                    | 'a'
+                                    | 'b'
+                                    | 'c'
+                                    | 'z'
+                                    | [
+                                        'a',
+                                        (key: 'a1') => TransformShape,
+                                    ]
+                                    | ['b', (key: 1n) => TransformShape]
+                                    | [
+                                        'c',
+                                        (key: true) => TransformShape,
+                                    ]
+                                    | [
+                                        'z',
+                                        (
+                                            key: 'never',
+                                        ) => TransformShape,
+                                    ]
+                                >
+                                | null
+                                a2:
+                                | 'a'
+                                | 'b'
+                                | 'c'
+                                | 'z'
+                                | NonEmptyArray<
+                                    | 'a'
+                                    | 'b'
+                                    | 'c'
+                                    | [
+                                        'a',
+                                        (key: 'a2') => TransformShape,
+                                    ]
+                                    | ['b', (key: 2) => TransformShape]
+                                    | ['c', (key: 0) => TransformShape]
+                                    | [
+                                        'z',
+                                        (
+                                            key: 'never' | null,
+                                        ) => TransformShape,
+                                        'never' | null,
+                                    ]
+                                >
+                                | null
+                            }
+                        }
                     >,
                     separator?: string | undefined,
                 ]
@@ -1064,27 +1064,27 @@ describe('DynamoDB Utils', () => {
 
         type entries =
             | ({
-                  a: 'a1'
-                  b: 1n
-                  c: true
-                  z: 'never'
-              } & {
-                  readonly PK: `A-a1-B-${string}-C-true`
-                  readonly SK: 'C-true-Z-never' | 'C-true-Z-DEFAULT'
-                  readonly GSIPK: 'never'
-                  readonly GSISK: 'Z-never-Z-never'
-              })
+                a: 'a1'
+                b: 1n
+                c: true
+                z: 'never'
+            } & {
+                readonly PK: `A-a1-B-${string}-C-true`
+                readonly SK: 'C-true-Z-never' | 'C-true-Z-DEFAULT'
+                readonly GSIPK: 'never'
+                readonly GSISK: 'Z-never-Z-never'
+            })
             | ({
-                  a: 'a2'
-                  b: 2
-                  c: 0
-                  z?: 'never' | null
-              } & {
-                  readonly PK: `A-a2-B-${string}-C-0`
-                  readonly SK: 'C-0-Z-DEFAULT' | 'C-0-Z-never'
-                  readonly GSIPK: 'never' | undefined
-                  readonly GSISK: 'Z-never' | 'Z-DEFAULT'
-              })
+                a: 'a2'
+                b: 2
+                c: 0
+                z?: 'never' | null
+            } & {
+                readonly PK: `A-a2-B-${string}-C-0`
+                readonly SK: 'C-0-Z-DEFAULT' | 'C-0-Z-never'
+                readonly GSIPK: 'never' | undefined
+                readonly GSISK: 'Z-never' | 'Z-DEFAULT'
+            })
 
         type expect_infer = isTrue<Equal<typeof testTableEntry.infer, entries>>
 
@@ -1129,51 +1129,51 @@ describe('DynamoDB Utils', () => {
                         | 'a'
                         | 'b'
                         | NonEmptyArray<
-                              | 'a'
-                              | 'b'
-                              | ['a', (key: 'a1' | 'a2') => TransformShape]
-                              | ['b', (key: 1n | 2) => TransformShape]
-                          >
+                            | 'a'
+                            | 'b'
+                            | ['a', (key: 'a1' | 'a2') => TransformShape]
+                            | ['b', (key: 1n | 2) => TransformShape]
+                        >
                         | null
                         | {
-                              discriminator: 'a'
-                              spec: {
-                                  a1:
-                                      | 'a'
-                                      | 'b'
-                                      | 'extra'
-                                      | NonEmptyArray<
-                                            | 'a'
-                                            | 'b'
-                                            | 'extra'
-                                            | [
-                                                  'a',
-                                                  (key: 'a1') => TransformShape,
-                                              ]
-                                            | ['b', (key: 1n) => TransformShape]
-                                            | [
-                                                  'extra',
-                                                  (
-                                                      key: 'extra',
-                                                  ) => TransformShape,
-                                              ]
-                                        >
-                                      | null
-                                  a2:
-                                      | 'a'
-                                      | 'b'
-                                      | NonEmptyArray<
-                                            | 'a'
-                                            | 'b'
-                                            | [
-                                                  'a',
-                                                  (key: 'a2') => TransformShape,
-                                              ]
-                                            | ['b', (key: 2) => TransformShape]
-                                        >
-                                      | null
-                              }
-                          }
+                            discriminator: 'a'
+                            spec: {
+                                a1:
+                                | 'a'
+                                | 'b'
+                                | 'extra'
+                                | NonEmptyArray<
+                                    | 'a'
+                                    | 'b'
+                                    | 'extra'
+                                    | [
+                                        'a',
+                                        (key: 'a1') => TransformShape,
+                                    ]
+                                    | ['b', (key: 1n) => TransformShape]
+                                    | [
+                                        'extra',
+                                        (
+                                            key: 'extra',
+                                        ) => TransformShape,
+                                    ]
+                                >
+                                | null
+                                a2:
+                                | 'a'
+                                | 'b'
+                                | NonEmptyArray<
+                                    | 'a'
+                                    | 'b'
+                                    | [
+                                        'a',
+                                        (key: 'a2') => TransformShape,
+                                    ]
+                                    | ['b', (key: 2) => TransformShape]
+                                >
+                                | null
+                            }
+                        }
                     >,
                     separator?: string | undefined,
                 ]

--- a/src/Rotorise.spec.ts
+++ b/src/Rotorise.spec.ts
@@ -662,7 +662,7 @@ describe('DynamoDB Utils', () => {
             }),
         ).toBeUndefined()
 
-        attest.instantiations([61103, 'instantiations'])
+        attest.instantiations([11704, 'instantiations'])
     })
 
     test('real world example', () => {
@@ -1084,5 +1084,131 @@ describe('DynamoDB Utils', () => {
                 separator?: string | undefined,
             ]
         >(null as any as Parameters<typeof base>)
+    })
+
+    test('transform parameter types narrow .key() attributes', () => {
+        type Device = {
+            type: 'android' | 'ios' | 'web' | 'desktop' | 'other'
+            deviceId: string
+            name: string
+            ip: string
+            location: string
+            userId: string
+        }
+
+        type DeviceVerification = {
+            device: Device
+            verificationId: string
+        }
+
+        const DeviceVerificationEntry = tableEntry<DeviceVerification>()({
+            PK: [
+                [
+                    'device',
+                    (x: Pick<Device, 'userId'>) => ({
+                        tag: 'user' as const,
+                        value: x.userId,
+                    }),
+                ],
+            ],
+            SK: [
+                [ /// ERROR FOUND - adding other sub attribute to the same key structure
+                    'device',
+                    (x: Pick<Device, 'userId'>) => ({
+                        tag: 'user' as const,
+                        value: x.userId,
+                    }),
+                ],
+                [
+                    'device',
+                    (x: Pick<Device, 'deviceId'>) => ({
+                        tag: 'device' as const,
+                        value: x.deviceId,
+                    }),
+                ],
+                [
+                    'verificationId',
+                    (x: string) => ({
+                        tag: 'verification' as const,
+                        value: x,
+                    }),
+                ],
+            ],
+            GSI1PK: [
+                [
+                    'device',
+                    (x: Pick<Device, 'userId'>) => ({
+                        tag: 'user' as const,
+                        value: x.userId,
+                    }),
+                ],
+            ],
+            GSI1SK: [
+                [
+                    'verificationId',
+                    (x: string) => ({
+                        tag: 'verification' as const,
+                        value: x,
+                    }),
+                ],
+            ],
+        })
+
+        // PK only needs userId — no cast required
+        expect(
+            DeviceVerificationEntry.key('PK', {
+                device: { userId: 'user-123' },
+            }),
+        ).toBe('user#user-123')
+
+        // SK needs userId AND deviceId (intersected from both transform params)
+        expect(
+            DeviceVerificationEntry.key('SK', {
+                device: { userId: 'user-123', deviceId: 'dev-456' },
+                verificationId: 'ver-789',
+            }),
+        ).toBe('user#user-123#device#dev-456#verification#ver-789')
+
+        // GSI1PK only needs userId
+        expect(
+            DeviceVerificationEntry.key('GSI1PK', {
+                device: { userId: 'user-123' },
+            }),
+        ).toBe('user#user-123')
+
+        // GSI1SK only needs verificationId
+        expect(
+            DeviceVerificationEntry.key('GSI1SK', {
+                verificationId: 'ver-789',
+            }),
+        ).toBe('verification#ver-789')
+
+        // SK requires both userId and deviceId on device
+        DeviceVerificationEntry.key('SK', {
+            // @ts-expect-error - missing userId
+            device: { deviceId: 'dev-456' },
+            verificationId: 'ver-789',
+        })
+
+        // SK requires both userId and deviceId on device
+        DeviceVerificationEntry.key('SK', {
+            // @ts-expect-error - missing deviceId
+            device: { userId: 'user-123' },
+            verificationId: 'ver-789',
+        })
+
+        // PK requires userId on device
+        DeviceVerificationEntry.key('PK', {
+            // @ts-expect-error - empty object missing userId
+            device: {},
+        })
+
+        // PK requires userId on device, not deviceId
+        DeviceVerificationEntry.key('PK', {
+            // @ts-expect-error - deviceId does not exist on Pick<Device, 'userId'>
+            device: { deviceId: 'dev-456' },
+        })
+
+        attest.instantiations([6187, 'instantiations'])
     })
 })

--- a/src/Rotorise.spec.ts
+++ b/src/Rotorise.spec.ts
@@ -1087,126 +1087,124 @@ describe('DynamoDB Utils', () => {
     })
 
     test('transform parameter types narrow .key() attributes', () => {
-        type Device = {
-            type: 'android' | 'ios' | 'web' | 'desktop' | 'other'
-            deviceId: string
-            name: string
-            ip: string
-            location: string
-            userId: string
+        type A = {
+            w: string
+            x: string
+            y: string
+            z: string
         }
 
-        type DeviceVerification = {
-            device: Device
-            verificationId: string
+        type B = {
+            a: A
+            b: string
         }
 
-        const DeviceVerificationEntry = tableEntry<DeviceVerification>()({
+        const Entry = tableEntry<B>()({
             PK: [
                 [
-                    'device',
-                    (x: Pick<Device, 'userId'>) => ({
-                        tag: 'user' as const,
-                        value: x.userId,
+                    'a',
+                    (x: Pick<A, 'w'>) => ({
+                        tag: 'W' as const,
+                        value: x.w,
                     }),
                 ],
             ],
             SK: [
                 [ /// ERROR FOUND - adding other sub attribute to the same key structure
-                    'device',
-                    (x: Pick<Device, 'userId'>) => ({
-                        tag: 'user' as const,
-                        value: x.userId,
+                    'a',
+                    (x: Pick<A, 'w'>) => ({
+                        tag: 'W' as const,
+                        value: x.w,
                     }),
                 ],
                 [
-                    'device',
-                    (x: Pick<Device, 'deviceId'>) => ({
-                        tag: 'device' as const,
-                        value: x.deviceId,
+                    'a',
+                    (x: Pick<A, 'x'>) => ({
+                        tag: 'X' as const,
+                        value: x.x,
                     }),
                 ],
                 [
-                    'verificationId',
+                    'b',
                     (x: string) => ({
-                        tag: 'verification' as const,
+                        tag: 'B_VAL' as const,
                         value: x,
                     }),
                 ],
             ],
             GSI1PK: [
                 [
-                    'device',
-                    (x: Pick<Device, 'userId'>) => ({
-                        tag: 'user' as const,
-                        value: x.userId,
+                    'a',
+                    (x: Pick<A, 'w'>) => ({
+                        tag: 'W' as const,
+                        value: x.w,
                     }),
                 ],
             ],
             GSI1SK: [
                 [
-                    'verificationId',
+                    'b',
                     (x: string) => ({
-                        tag: 'verification' as const,
+                        tag: 'B_VAL' as const,
                         value: x,
                     }),
                 ],
             ],
         })
 
-        // PK only needs userId — no cast required
+        // PK only needs w
         expect(
-            DeviceVerificationEntry.key('PK', {
-                device: { userId: 'user-123' },
+            Entry.key('PK', {
+                a: { w: 'w1' },
             }),
-        ).toBe('user#user-123')
+        ).toBe('W#w1')
 
-        // SK needs userId AND deviceId (intersected from both transform params)
+        // SK needs w AND x (intersected from both transform params)
         expect(
-            DeviceVerificationEntry.key('SK', {
-                device: { userId: 'user-123', deviceId: 'dev-456' },
-                verificationId: 'ver-789',
+            Entry.key('SK', {
+                a: { w: 'w1', x: 'x1' },
+                b: 'b1',
             }),
-        ).toBe('user#user-123#device#dev-456#verification#ver-789')
+        ).toBe('W#w1#X#x1#B_VAL#b1')
 
-        // GSI1PK only needs userId
+        // GSI1PK only needs w
         expect(
-            DeviceVerificationEntry.key('GSI1PK', {
-                device: { userId: 'user-123' },
+            Entry.key('GSI1PK', {
+                a: { w: 'w1' },
             }),
-        ).toBe('user#user-123')
+        ).toBe('W#w1')
 
-        // GSI1SK only needs verificationId
+        // GSI1SK only needs b
         expect(
-            DeviceVerificationEntry.key('GSI1SK', {
-                verificationId: 'ver-789',
+            Entry.key('GSI1SK', {
+                b: 'b1',
             }),
-        ).toBe('verification#ver-789')
+        ).toBe('B_VAL#b1')
 
-        // SK requires both userId and deviceId on device
-        DeviceVerificationEntry.key('SK', {
-            // @ts-expect-error - missing userId
-            device: { deviceId: 'dev-456' },
-            verificationId: 'ver-789',
+        // SK requires both w and x on a
+        Entry.key('SK', {
+            // @ts-expect-error - missing w
+            a: { x: 'x1' },
+            b: 'b1',
         })
 
-        // SK requires both userId and deviceId on device
-        DeviceVerificationEntry.key('SK', {
-            // @ts-expect-error - missing deviceId
-            device: { userId: 'user-123' },
-            verificationId: 'ver-789',
+        // SK requires both w and x on a
+        Entry.key('SK', {
+            // @ts-expect-error - missing x
+            a: { w: 'w1' },
+            b: 'b1',
         })
 
-        // PK requires userId on device
-        DeviceVerificationEntry.key('PK', {
-            // @ts-expect-error - empty object missing userId
-            device: {},
+        // PK requires w on a
+        Entry.key('PK', {
+            // @ts-expect-error - empty object missing w
+            a: {},
         })
 
-        // PK requires userId on device, not deviceId
-        DeviceVerificationEntry.key('PK', {
-            // @ts-expect-error - deviceId does not exist on Pick<Device, 'userId'>
-            device: { deviceId: 'dev-456' },
+        // PK requires w on a, not x
+        Entry.key('PK', {
+            // @ts-expect-error - x does not exist on Pick<A, 'w'>
+            a: { x: 'x1' },
         })
 
         attest.instantiations([6396, 'instantiations'])

--- a/src/Rotorise.spec.ts
+++ b/src/Rotorise.spec.ts
@@ -37,7 +37,7 @@ describe('DynamoDB Utils', () => {
             >,
         )
 
-        attest.instantiations([1726, 'instantiations'])
+        attest.instantiations([2026, 'instantiations'])
     })
 
     it('CompositeKeyBuilder', () => {
@@ -170,7 +170,7 @@ describe('DynamoDB Utils', () => {
             >,
         )
 
-        attest.instantiations([5778, 'instantiations'])
+        attest.instantiations([5678, 'instantiations'])
     })
 
     it('tableEntry', () => {
@@ -336,7 +336,7 @@ describe('DynamoDB Utils', () => {
             ),
         ).toBe(1)
 
-        attest.instantiations([7674, 'instantiations'])
+        attest.instantiations([7743, 'instantiations'])
     })
 
     test('path from infer then toString', () => {
@@ -372,7 +372,7 @@ describe('DynamoDB Utils', () => {
         )
         expect(testTableEntry.path().PK.toString()).toBe('PK')
 
-        attest.instantiations([1169, 'instantiations'])
+        attest.instantiations([1424, 'instantiations'])
     })
 
     test('table Entry with transform and discriminator ', () => {
@@ -662,7 +662,7 @@ describe('DynamoDB Utils', () => {
             }),
         ).toBeUndefined()
 
-        attest.instantiations([11704, 'instantiations'])
+        attest.instantiations([11931, 'instantiations'])
     })
 
     test('real world example', () => {
@@ -874,7 +874,7 @@ describe('DynamoDB Utils', () => {
             { depth: 2 },
         ) satisfies 'TAG#A#ID2#yolo'
 
-        attest.instantiations([31539, 'instantiations'])
+        attest.instantiations([32307, 'instantiations'])
     })
 
     test('schema allows for nullish values if has transform', () => {
@@ -1209,6 +1209,6 @@ describe('DynamoDB Utils', () => {
             device: { deviceId: 'dev-456' },
         })
 
-        attest.instantiations([6187, 'instantiations'])
+        attest.instantiations([6396, 'instantiations'])
     })
 })

--- a/src/Rotorise.ts
+++ b/src/Rotorise.ts
@@ -16,23 +16,23 @@ export type CompositeKeyParamsImpl<
     skip extends number = 1,
 > = Entity extends unknown
     ? evaluate<
-        Pick<
-            Entity,
-            extractHeadOrPass<
-                SliceFromStart<
-                    InputSpec,
-                    number extends skip ? 1 : skip
-                >[number]
-            > &
-            keyof Entity
-        > &
-        Partial<
-            Pick<
-                Entity,
-                extractHeadOrPass<InputSpec[number]> & keyof Entity
-            >
-        >
-    >
+          Pick<
+              Entity,
+              extractHeadOrPass<
+                  SliceFromStart<
+                      InputSpec,
+                      number extends skip ? 1 : skip
+                  >[number]
+              > &
+                  keyof Entity
+          > &
+              Partial<
+                  Pick<
+                      Entity,
+                      extractHeadOrPass<InputSpec[number]> & keyof Entity
+                  >
+              >
+      >
     : never
 
 export type CompositeKeyParams<
@@ -46,16 +46,16 @@ type joinable = string | number | bigint | boolean | null | undefined
 type ExtractHelper<Key, Value> = Value extends joinable
     ? [Key, Value]
     : Value extends {
-        tag: infer Tag extends string
-        value: infer Value extends joinable
-    }
-    ? [Tag, Value]
-    : Value extends {
-        tag?: undefined
-        value: infer Value extends joinable
-    }
-    ? [never, Value]
-    : never
+            tag: infer Tag extends string
+            value: infer Value extends joinable
+        }
+      ? [Tag, Value]
+      : Value extends {
+              tag?: undefined
+              value: infer Value extends joinable
+          }
+        ? [never, Value]
+        : never
 
 type ExtractPair<Entity, Spec> = Spec extends [
     infer Key extends string,
@@ -65,8 +65,8 @@ type ExtractPair<Entity, Spec> = Spec extends [
 ]
     ? ExtractHelper<Uppercase<Key>, Value>
     : Spec extends keyof Entity & string
-    ? [Uppercase<Spec>, Entity[Spec] & joinable]
-    : never
+      ? [Uppercase<Spec>, Entity[Spec] & joinable]
+      : never
 
 type CompositeKeyStringBuilder<
     Entity,
@@ -77,26 +77,26 @@ type CompositeKeyStringBuilder<
     AllAcc extends string = never,
 > = Spec extends [infer Head, ...infer Tail]
     ? ExtractPair<Entity, Head> extends [
-        infer Key extends joinable,
-        infer Value extends joinable,
-    ]
-    ? CompositeKeyStringBuilder<
-        Entity,
-        Tail,
-        Separator,
-        KeepIntermediate,
-        Acc extends ''
-        ? [Key] extends [never]
-        ? `${Value}`
-        : `${Key}${Separator}${Value}`
-        : [Key] extends [never]
-        ? `${Acc}${Separator}${Value}`
-        : `${Acc}${Separator}${Key}${Separator}${Value}`,
-        KeepIntermediate extends true
-        ? AllAcc | (Acc extends '' ? never : Acc)
+          infer Key extends joinable,
+          infer Value extends joinable,
+      ]
+        ? CompositeKeyStringBuilder<
+              Entity,
+              Tail,
+              Separator,
+              KeepIntermediate,
+              Acc extends ''
+                  ? [Key] extends [never]
+                      ? `${Value}`
+                      : `${Key}${Separator}${Value}`
+                  : [Key] extends [never]
+                    ? `${Acc}${Separator}${Value}`
+                    : `${Acc}${Separator}${Key}${Separator}${Value}`,
+              KeepIntermediate extends true
+                  ? AllAcc | (Acc extends '' ? never : Acc)
+                  : never
+          >
         : never
-    >
-    : never
     : AllAcc | Acc
 
 type CompositeKeyBuilderImpl<
@@ -107,15 +107,15 @@ type CompositeKeyBuilderImpl<
     isPartial extends boolean = false,
 > = Entity extends unknown
     ? CompositeKeyStringBuilder<
-        Entity,
-        [Deep] extends [never]
-        ? Spec
-        : number extends Deep
-        ? Spec
-        : SliceFromStart<Spec, Deep>,
-        Separator,
-        boolean extends isPartial ? false : isPartial
-    >
+          Entity,
+          [Deep] extends [never]
+              ? Spec
+              : number extends Deep
+                ? Spec
+                : SliceFromStart<Spec, Deep>,
+          Separator,
+          boolean extends isPartial ? false : isPartial
+      >
     : never
 
 export type CompositeKeyBuilder<
@@ -138,9 +138,9 @@ type InputSpecShape =
     ([PropertyKey, (key: any) => unknown, ...unknown[]] | PropertyKey)[]
 export type TransformShape =
     | {
-        tag?: string
-        value: joinable
-    }
+          tag?: string
+          value: joinable
+      }
     | joinable
 
 type ComputeTableKeyType<
@@ -151,10 +151,10 @@ type ComputeTableKeyType<
 > = Spec extends InputSpecShape
     ? CompositeKeyBuilderImpl<Entity, Spec, Separator, number, false>
     : Spec extends keyof Entity
-    ? Replace<Entity[Spec], null, undefined>
-    : Spec extends null
-    ? NullAs
-    : never
+      ? Replace<Entity[Spec], null, undefined>
+      : Spec extends null
+        ? NullAs
+        : never
 
 type TableEntryImpl<
     Entity,
@@ -162,17 +162,17 @@ type TableEntryImpl<
     Separator extends string = '#',
 > = Entity extends unknown
     ? {
-        [Key in keyof Schema]: Schema[Key] extends DiscriminatedSchemaShape
-        ? ComputeTableKeyType<
-            Entity,
-            ValueOf<
-                Schema[Key]['spec'],
-                ValueOf<Entity, Schema[Key]['discriminator']>
-            >,
-            Separator
-        >
-        : ComputeTableKeyType<Entity, Schema[Key], Separator>
-    } & Entity
+          [Key in keyof Schema]: Schema[Key] extends DiscriminatedSchemaShape
+              ? ComputeTableKeyType<
+                    Entity,
+                    ValueOf<
+                        Schema[Key]['spec'],
+                        ValueOf<Entity, Schema[Key]['discriminator']>
+                    >,
+                    Separator
+                >
+              : ComputeTableKeyType<Entity, Schema[Key], Separator>
+      } & Entity
     : never
 
 export type TableEntry<
@@ -183,14 +183,14 @@ export type TableEntry<
 
 type InputSpec<E> = {
     [key in keyof E]:
-    | (undefined extends E[key]
-        ? [
-            key,
-            (key: Exclude<E[key], undefined>) => TransformShape,
-            Exclude<E[key], undefined>,
-        ]
-        : [key, (key: Exclude<E[key], undefined>) => TransformShape])
-    | (undefined extends E[key] ? never : null extends E[key] ? never : key)
+        | (undefined extends E[key]
+              ? [
+                    key,
+                    (key: Exclude<E[key], undefined>) => TransformShape,
+                    Exclude<E[key], undefined>,
+                ]
+              : [key, (key: Exclude<E[key], undefined>) => TransformShape])
+        | (undefined extends E[key] ? never : null extends E[key] ? never : key)
 }[keyof E]
 
 type extractHeadOrPass<T> = T extends readonly unknown[] ? T[0] : T
@@ -204,20 +204,20 @@ type FullKeySpecSimpleShape = InputSpecShape | string | null
 
 type DiscriminatedSchema<Entity, E> = {
     [key in keyof E]: E[key] extends PropertyKey
-    ? {
-        discriminator: key
-        spec: {
-            [val in E[key]]: FullKeySpecSimple<
-                Extract<
-                    Entity,
-                    {
-                        [k in key]: val
-                    }
-                >
-            >
-        }
-    }
-    : never
+        ? {
+              discriminator: key
+              spec: {
+                  [val in E[key]]: FullKeySpecSimple<
+                      Extract<
+                          Entity,
+                          {
+                              [k in key]: val
+                          }
+                      >
+                  >
+              }
+          }
+        : never
 }[keyof E]
 
 type FullKeySpec<Entity> =
@@ -231,7 +231,7 @@ const chainableNoOpProxy: unknown = new Proxy(() => chainableNoOpProxy, {
 })
 
 const createPathProxy = <T>(path = ''): T => {
-    return new Proxy(() => { }, {
+    return new Proxy(() => {}, {
         get: (_target, prop) => {
             if (typeof prop === 'string') {
                 if (prop === 'toString') {
@@ -242,8 +242,8 @@ const createPathProxy = <T>(path = ''): T => {
                     path === ''
                         ? prop
                         : !Number.isNaN(Number.parseInt(prop))
-                            ? `${path}[${prop}]`
-                            : `${path}.${prop}`,
+                          ? `${path}[${prop}]`
+                          : `${path}.${prop}`,
                 )
             }
         },
@@ -252,177 +252,177 @@ const createPathProxy = <T>(path = ''): T => {
 
 const key =
     <const Entity>() =>
-        <
-            const Schema extends Record<
-                string,
-                | InputSpec<MergeIntersectionObject<Entity>>[]
-                | keyof Entity
-                | {
-                    discriminator: keyof Entity
-                    spec: {
-                        [val in string]:
-                        | InputSpec<MergeIntersectionObject<Entity>>[]
-                        | keyof Entity
-                    }
-                }
-            >,
-            Separator extends string = '#',
-        >(
-            schema: Schema,
-            separator: Separator = '#' as Separator,
-        ) =>
-            <
-                const Key extends keyof Schema,
-                const Config extends {
-                    depth?: number
-                    allowPartial?: boolean
-                    enforceBoundary?: boolean
-                },
-                const Attributes extends Partial<Entity>,
-            >(
-                key: Key,
-                attributes: Attributes,
-                config?: Config,
-            ): string | undefined => {
-                const case_ = schema[key]
+    <
+        const Schema extends Record<
+            string,
+            | InputSpec<MergeIntersectionObject<Entity>>[]
+            | keyof Entity
+            | {
+                  discriminator: keyof Entity
+                  spec: {
+                      [val in string]:
+                          | InputSpec<MergeIntersectionObject<Entity>>[]
+                          | keyof Entity
+                  }
+              }
+        >,
+        Separator extends string = '#',
+    >(
+        schema: Schema,
+        separator: Separator = '#' as Separator,
+    ) =>
+    <
+        const Key extends keyof Schema,
+        const Config extends {
+            depth?: number
+            allowPartial?: boolean
+            enforceBoundary?: boolean
+        },
+        const Attributes extends Partial<Entity>,
+    >(
+        key: Key,
+        attributes: Attributes,
+        config?: Config,
+    ): string | undefined => {
+        const case_ = schema[key]
 
-                if (case_ === undefined) {
-                    throw new Error(`Key ${key.toString()} not found in schema`)
-                }
-                let structure: InputSpec<MergeIntersectionObject<Entity>>[]
+        if (case_ === undefined) {
+            throw new Error(`Key ${key.toString()} not found in schema`)
+        }
+        let structure: InputSpec<MergeIntersectionObject<Entity>>[]
 
-                if (Array.isArray(case_)) {
-                    structure = case_
-                } else if (typeof case_ === 'object') {
-                    const discriminator =
-                        attributes[case_.discriminator as keyof Attributes]
-                    if (discriminator === undefined) {
-                        throw new Error(
-                            `Discriminator ${case_.discriminator.toString()} not found in ${JSON.stringify(attributes)}`,
-                        )
-                    }
-                    const val = case_.spec[discriminator as keyof typeof case_.spec]
-                    if (val === undefined) {
-                        throw new Error(
-                            `Discriminator value ${discriminator?.toString()} not found in ${JSON.stringify(attributes)}`,
-                        )
-                    }
-                    if (val === null) {
-                        return undefined
-                    }
-
-                    if (!Array.isArray(val)) {
-                        return attributes[val as keyof Attributes] as never
-                    }
-
-                    structure = val
-                } else {
-                    const value = attributes[case_ as keyof Attributes]
-                    if (value == null) return undefined as never
-
-                    return value as never
-                }
-
-                const fullLength = structure.length
-
-                if (config?.depth !== undefined) {
-                    structure = structure.slice(0, config.depth) as never
-                }
-                const composite: joinable[] = []
-
-                for (const keySpec of structure) {
-                    const [key, transform, Default] = Array.isArray(keySpec)
-                        ? keySpec
-                        : [keySpec]
-
-                    const value = attributes[key as keyof Attributes] ?? Default
-
-                    if (transform && value !== undefined) {
-                        const transformed = transform(value as never)
-                        if (typeof transformed === 'object' && transformed !== null) {
-                            if (transformed.tag !== undefined)
-                                composite.push(transformed.tag)
-                            composite.push(transformed.value)
-                        } else {
-                            composite.push(key.toString().toUpperCase())
-                            composite.push(transformed)
-                        }
-                    } else if (value !== undefined && value !== null && value !== '') {
-                        composite.push(key.toString().toUpperCase())
-                        composite.push(value as joinable)
-                    } else if (config?.allowPartial) {
-                        break
-                    } else {
-                        throw new Error(
-                            `buildCompositeKey: Attribute ${key.toString()} not found in ${JSON.stringify(attributes)}`,
-                        )
-                    }
-                }
-
-                if (config?.enforceBoundary && fullLength * 2 > composite.length) {
-                    composite.push('')
-                }
-
-                return composite.join(separator) as never
+        if (Array.isArray(case_)) {
+            structure = case_
+        } else if (typeof case_ === 'object') {
+            const discriminator =
+                attributes[case_.discriminator as keyof Attributes]
+            if (discriminator === undefined) {
+                throw new Error(
+                    `Discriminator ${case_.discriminator.toString()} not found in ${JSON.stringify(attributes)}`,
+                )
             }
+            const val = case_.spec[discriminator as keyof typeof case_.spec]
+            if (val === undefined) {
+                throw new Error(
+                    `Discriminator value ${discriminator?.toString()} not found in ${JSON.stringify(attributes)}`,
+                )
+            }
+            if (val === null) {
+                return undefined
+            }
+
+            if (!Array.isArray(val)) {
+                return attributes[val as keyof Attributes] as never
+            }
+
+            structure = val
+        } else {
+            const value = attributes[case_ as keyof Attributes]
+            if (value == null) return undefined as never
+
+            return value as never
+        }
+
+        const fullLength = structure.length
+
+        if (config?.depth !== undefined) {
+            structure = structure.slice(0, config.depth) as never
+        }
+        const composite: joinable[] = []
+
+        for (const keySpec of structure) {
+            const [key, transform, Default] = Array.isArray(keySpec)
+                ? keySpec
+                : [keySpec]
+
+            const value = attributes[key as keyof Attributes] ?? Default
+
+            if (transform && value !== undefined) {
+                const transformed = transform(value as never)
+                if (typeof transformed === 'object' && transformed !== null) {
+                    if (transformed.tag !== undefined)
+                        composite.push(transformed.tag)
+                    composite.push(transformed.value)
+                } else {
+                    composite.push(key.toString().toUpperCase())
+                    composite.push(transformed)
+                }
+            } else if (value !== undefined && value !== null && value !== '') {
+                composite.push(key.toString().toUpperCase())
+                composite.push(value as joinable)
+            } else if (config?.allowPartial) {
+                break
+            } else {
+                throw new Error(
+                    `buildCompositeKey: Attribute ${key.toString()} not found in ${JSON.stringify(attributes)}`,
+                )
+            }
+        }
+
+        if (config?.enforceBoundary && fullLength * 2 > composite.length) {
+            composite.push('')
+        }
+
+        return composite.join(separator) as never
+    }
 
 const toEntry =
     <const Entity extends Record<string, unknown>>() =>
-        <
-            const Schema extends Record<
-                string,
-                | InputSpec<MergeIntersectionObject<Entity>>[]
-                | keyof Entity
-                | {
-                    discriminator: keyof Entity
-                    spec: {
-                        [val in string]:
-                        | InputSpec<MergeIntersectionObject<Entity>>[]
-                        | keyof Entity
-                    }
-                }
-            >,
-            Separator extends string = '#',
-        >(
-            schema: Schema,
-            separator: Separator = '#' as Separator,
-        ) =>
-            <const ExactEntity extends Entity>(
-                item: ExactEntity,
-            ): ExactEntity extends infer E extends Entity
-                ? TableEntryImpl<E, Schema, Separator>
-                : never => {
-                const entry = { ...item }
+    <
+        const Schema extends Record<
+            string,
+            | InputSpec<MergeIntersectionObject<Entity>>[]
+            | keyof Entity
+            | {
+                  discriminator: keyof Entity
+                  spec: {
+                      [val in string]:
+                          | InputSpec<MergeIntersectionObject<Entity>>[]
+                          | keyof Entity
+                  }
+              }
+        >,
+        Separator extends string = '#',
+    >(
+        schema: Schema,
+        separator: Separator = '#' as Separator,
+    ) =>
+    <const ExactEntity extends Entity>(
+        item: ExactEntity,
+    ): ExactEntity extends infer E extends Entity
+        ? TableEntryImpl<E, Schema, Separator>
+        : never => {
+        const entry = { ...item }
 
-                for (const key_ in schema) {
-                    const val = key<Entity>()(schema, separator)(key_, item)
-                    if (val !== undefined) {
-                        entry[key_] = val satisfies string as never
-                    }
-                }
-                // console.log({ entry })
-                return entry as never
+        for (const key_ in schema) {
+            const val = key<Entity>()(schema, separator)(key_, item)
+            if (val !== undefined) {
+                entry[key_] = val satisfies string as never
             }
+        }
+        // console.log({ entry })
+        return entry as never
+    }
 
 const fromEntry =
     <const Entity extends Record<string, unknown>>() =>
-        <
-            const Schema extends Record<string, FullKeySpecShape>,
-            Separator extends string = '#',
-        >(
-            schema: Schema,
-        ) =>
-            <const Entry extends TableEntryImpl<Entity, Schema, Separator>>(
-                entry: Entry,
-            ): DistributiveOmit<Entry, keyof Schema> => {
-                const item = { ...entry }
+    <
+        const Schema extends Record<string, FullKeySpecShape>,
+        Separator extends string = '#',
+    >(
+        schema: Schema,
+    ) =>
+    <const Entry extends TableEntryImpl<Entity, Schema, Separator>>(
+        entry: Entry,
+    ): DistributiveOmit<Entry, keyof Schema> => {
+        const item = { ...entry }
 
-                for (const key_ in schema) {
-                    delete item[key_]
-                }
-                // console.log({ item })
-                return item as never
-            }
+        for (const key_ in schema) {
+            delete item[key_]
+        }
+        // console.log({ item })
+        return item as never
+    }
 
 type ProcessSpecType<
     Entity,
@@ -431,14 +431,14 @@ type ProcessSpecType<
 > = Spec extends string
     ? DistributivePick<Entity, Spec>
     : Spec extends InputSpecShape
-    ? CompositeKeyParamsImpl<
-        Entity,
-        Spec,
-        Config['allowPartial'] extends true
-        ? 1
-        : Extract<Config['depth'], number>
-    >
-    : never
+      ? CompositeKeyParamsImpl<
+            Entity,
+            Spec,
+            Config['allowPartial'] extends true
+                ? 1
+                : Extract<Config['depth'], number>
+        >
+      : never
 
 // Cache commonly used conditional types
 type SpecConfig<Spec> = Spec extends string ? never : SpecConfigShape
@@ -480,16 +480,16 @@ type OptimizedAttributes<
     Config extends SpecConfigShape,
 > = Spec extends DiscriminatedSchemaShape
     ? {
-        [K in Spec['discriminator']]: {
-            [V in keyof Spec['spec']]: ProcessVariant<
-                Entity,
-                K,
-                V,
-                Spec,
-                Config
-            >
-        }[keyof Spec['spec']]
-    }[Spec['discriminator']]
+          [K in Spec['discriminator']]: {
+              [V in keyof Spec['spec']]: ProcessVariant<
+                  Entity,
+                  K,
+                  V,
+                  Spec,
+                  Config
+              >
+          }[keyof Spec['spec']]
+      }[Spec['discriminator']]
     : ProcessSpecType<Entity, Spec, Config>
 
 type ProcessKey<
@@ -502,18 +502,18 @@ type ProcessKey<
 > = [Entity] extends [never]
     ? never
     : Spec extends keyof Entity
-    ? Replace<ValueOf<Attributes>, null, undefined>
-    : Spec extends InputSpecShape
-    ? CompositeKeyBuilderImpl<
-        Entity,
-        Spec,
-        Separator,
-        Exclude<Config['depth'], undefined>,
-        Exclude<Config['allowPartial'], undefined>
-    >
-    : Spec extends null
-    ? NullAs
-    : never
+      ? Replace<ValueOf<Attributes>, null, undefined>
+      : Spec extends InputSpecShape
+        ? CompositeKeyBuilderImpl<
+              Entity,
+              Spec,
+              Separator,
+              Exclude<Config['depth'], undefined>,
+              Exclude<Config['allowPartial'], undefined>
+          >
+        : Spec extends null
+          ? NullAs
+          : never
 
 type OptimizedBuildedKey<
     Entity,
@@ -523,15 +523,15 @@ type OptimizedBuildedKey<
     Attributes,
 > = Entity extends unknown
     ? Spec extends DiscriminatedSchemaShape
-    ? ProcessKey<
-        Entity,
-        ValueOf<Spec['spec'], ValueOf<Entity, Spec['discriminator']>>,
-        Separator,
-        undefined,
-        Config,
-        Attributes
-    >
-    : ProcessKey<Entity, Spec, Separator, undefined, Config, Attributes>
+        ? ProcessKey<
+              Entity,
+              ValueOf<Spec['spec'], ValueOf<Entity, Spec['discriminator']>>,
+              Separator,
+              undefined,
+              Config,
+              Attributes
+          >
+        : ProcessKey<Entity, Spec, Separator, undefined, Config, Attributes>
     : never
 
 type TableEntryDefinition<Entity, Schema, Separator extends string> = {
@@ -547,12 +547,12 @@ type TableEntryDefinition<Entity, Schema, Separator extends string> = {
         const Attributes extends OptimizedAttributes<Entity, Spec, Config_>,
         Spec = Schema[Key],
         Config_ extends SpecConfigShape = [SpecConfigShape] extends [Config] // exclude undefined param
-        ? {
-            depth?: undefined
-            allowPartial?: undefined
-            enforceBoundary?: boolean
-        }
-        : Config,
+            ? {
+                  depth?: undefined
+                  allowPartial?: undefined
+                  enforceBoundary?: boolean
+              }
+            : Config,
     >(
         key: Key,
         attributes: Attributes,
@@ -564,18 +564,18 @@ type TableEntryDefinition<Entity, Schema, Separator extends string> = {
 
 export const tableEntry =
     <const Entity extends Record<string, unknown>>() =>
-        <
-            const Schema extends Record<string, FullKeySpec<Entity>>,
-            Separator extends string = '#',
-        >(
-            schema: Schema,
-            separator: Separator = '#' as Separator,
-        ): TableEntryDefinition<Entity, Schema, Separator> => {
-            return {
-                toEntry: toEntry()(schema as never, separator) as never,
-                fromEntry: fromEntry()(schema as never) as never,
-                key: key()(schema as never, separator) as never,
-                infer: chainableNoOpProxy as never,
-                path: () => createPathProxy() as never,
-            }
+    <
+        const Schema extends Record<string, FullKeySpec<Entity>>,
+        Separator extends string = '#',
+    >(
+        schema: Schema,
+        separator: Separator = '#' as Separator,
+    ): TableEntryDefinition<Entity, Schema, Separator> => {
+        return {
+            toEntry: toEntry()(schema as never, separator) as never,
+            fromEntry: fromEntry()(schema as never) as never,
+            key: key()(schema as never, separator) as never,
+            infer: chainableNoOpProxy as never,
+            path: () => createPathProxy() as never,
         }
+    }

--- a/src/Rotorise.ts
+++ b/src/Rotorise.ts
@@ -450,7 +450,14 @@ type SpecConfigShape = {
 }
 
 // Pre-compute discriminated variant types
-type VariantType<Entity, K extends PropertyKey, V extends PropertyKey> = [
+// Pre-compute discriminated variant types
+type ExtractVariant<Entity, K extends PropertyKey, V extends PropertyKey> = [
+    Entity,
+] extends [never]
+    ? never
+    : Extract<Entity, { [k in K]: V }>
+
+type TagVariant<Entity, K extends PropertyKey, V extends PropertyKey> = [
     Entity,
 ] extends [never]
     ? { [k in K]: V }
@@ -463,9 +470,9 @@ type ProcessVariant<
     V extends PropertyKey,
     Spec extends DiscriminatedSchemaShape,
     Config extends SpecConfigShape,
-> = VariantType<
+> = TagVariant<
     ProcessSpecType<
-        VariantType<Entity, K, V>,
+        ExtractVariant<Entity, K, V>,
         Spec['spec'][V & keyof Spec['spec']],
         Config
     >,

--- a/src/Rotorise.ts
+++ b/src/Rotorise.ts
@@ -542,8 +542,8 @@ type OptimizedBuildedKey<
     : never
 
 type TableEntryDefinition<Entity, Schema, Separator extends string> = {
-    toEntry: <const ExactEntity extends Exact<Entity, ExactEntity>>(
-        item: ExactEntity,
+    toEntry: <const ExactEntity>(
+        item: Exact<Entity, ExactEntity>,
     ) => TableEntryImpl<ExactEntity, Schema, Separator>
     fromEntry: <const Entry extends TableEntryImpl<Entity, Schema, Separator>>(
         entry: Entry,

--- a/src/Rotorise.ts
+++ b/src/Rotorise.ts
@@ -10,6 +10,8 @@ import type {
     evaluate,
 } from './utils'
 
+type PartialPick<T, K extends keyof T> = { [P in K]?: T[P] }
+
 export type CompositeKeyParamsImpl<
     Entity,
     InputSpec extends InputSpecShape,
@@ -26,11 +28,9 @@ export type CompositeKeyParamsImpl<
               > &
                   keyof Entity
           > &
-              Partial<
-                  Pick<
-                      Entity,
-                      extractHeadOrPass<InputSpec[number]> & keyof Entity
-                  >
+              PartialPick<
+                  Entity,
+                  extractHeadOrPass<InputSpec[number]> & keyof Entity
               >
       >
     : never

--- a/src/Rotorise.ts
+++ b/src/Rotorise.ts
@@ -43,19 +43,18 @@ export type CompositeKeyParams<
 
 type joinable = string | number | bigint | boolean | null | undefined
 
-type ExtractHelper<Key, Value> = Value extends joinable
-    ? [Key, Value]
-    : Value extends {
-            tag: infer Tag extends string
-            value: infer Value extends joinable
-        }
-      ? [Tag, Value]
-      : Value extends {
-              tag?: undefined
-              value: infer Value extends joinable
-          }
-        ? [never, Value]
-        : never
+type ExtractHelper<Key, Value> = Value extends object
+    ? Value extends {
+          tag: infer Tag extends string
+          value: infer Value extends joinable
+      }
+        ? [Tag, Value]
+        : Value extends {
+                value: infer Value extends joinable
+            }
+          ? [never, Value]
+          : never
+    : [Key, Value]
 
 type ExtractPair<Entity, Spec> = Spec extends [
     infer Key extends string,

--- a/src/Rotorise.ts
+++ b/src/Rotorise.ts
@@ -41,6 +41,33 @@ export type CompositeKeyParams<
     skip extends number = 1,
 > = CompositeKeyParamsImpl<Entity, FullSpec, skip>
 
+type CompositeKeyBuilderImpl<
+    Entity,
+    Spec,
+    Separator extends string = '#',
+    Deep extends number = number,
+    isPartial extends boolean = false,
+> = Entity extends unknown
+    ? CompositeKeyStringBuilder<
+          Entity,
+          [Deep] extends [never]
+              ? Spec
+              : number extends Deep
+                ? Spec
+                : SliceFromStart<Spec, Deep>,
+          Separator,
+          boolean extends isPartial ? false : isPartial
+      >
+    : never
+
+export type CompositeKeyBuilder<
+    Entity extends Record<string, unknown>,
+    Spec extends InputSpec<MergeIntersectionObject<Entity>>[],
+    Separator extends string = '#',
+    Deep extends number = number,
+    isPartial extends boolean = false,
+> = CompositeKeyBuilderImpl<Entity, Spec, Separator, Deep, isPartial>
+
 type joinable = string | number | bigint | boolean | null | undefined
 
 type ExtractHelper<Key, Value> = Value extends object
@@ -97,33 +124,6 @@ type CompositeKeyStringBuilder<
           >
         : never
     : AllAcc | Acc
-
-type CompositeKeyBuilderImpl<
-    Entity,
-    Spec,
-    Separator extends string = '#',
-    Deep extends number = number,
-    isPartial extends boolean = false,
-> = Entity extends unknown
-    ? CompositeKeyStringBuilder<
-          Entity,
-          [Deep] extends [never]
-              ? Spec
-              : number extends Deep
-                ? Spec
-                : SliceFromStart<Spec, Deep>,
-          Separator,
-          boolean extends isPartial ? false : isPartial
-      >
-    : never
-
-export type CompositeKeyBuilder<
-    Entity extends Record<string, unknown>,
-    Spec extends InputSpec<MergeIntersectionObject<Entity>>[],
-    Separator extends string = '#',
-    Deep extends number = number,
-    isPartial extends boolean = false,
-> = CompositeKeyBuilderImpl<Entity, Spec, Separator, Deep, isPartial>
 
 type DiscriminatedSchemaShape = {
     discriminator: PropertyKey

--- a/src/Rotorise.ts
+++ b/src/Rotorise.ts
@@ -16,23 +16,23 @@ export type CompositeKeyParamsImpl<
     skip extends number = 1,
 > = Entity extends unknown
     ? evaluate<
-          Pick<
-              Entity,
-              extractHeadOrPass<
-                  SliceFromStart<
-                      InputSpec,
-                      number extends skip ? 1 : skip
-                  >[number]
-              > &
-                  keyof Entity
-          > &
-              Partial<
-                  Pick<
-                      Entity,
-                      extractHeadOrPass<InputSpec[number]> & keyof Entity
-                  >
-              >
-      >
+        Pick<
+            Entity,
+            extractHeadOrPass<
+                SliceFromStart<
+                    InputSpec,
+                    number extends skip ? 1 : skip
+                >[number]
+            > &
+            keyof Entity
+        > &
+        Partial<
+            Pick<
+                Entity,
+                extractHeadOrPass<InputSpec[number]> & keyof Entity
+            >
+        >
+    >
     : never
 
 export type CompositeKeyParams<
@@ -46,16 +46,16 @@ type joinable = string | number | bigint | boolean | null | undefined
 type ExtractHelper<Key, Value> = Value extends joinable
     ? [Key, Value]
     : Value extends {
-            tag: infer Tag extends string
-            value: infer Value extends joinable
-        }
-      ? [Tag, Value]
-      : Value extends {
-              tag?: undefined
-              value: infer Value extends joinable
-          }
-        ? [never, Value]
-        : never
+        tag: infer Tag extends string
+        value: infer Value extends joinable
+    }
+    ? [Tag, Value]
+    : Value extends {
+        tag?: undefined
+        value: infer Value extends joinable
+    }
+    ? [never, Value]
+    : never
 
 type ExtractPair<Entity, Spec> = Spec extends [
     infer Key extends string,
@@ -65,8 +65,8 @@ type ExtractPair<Entity, Spec> = Spec extends [
 ]
     ? ExtractHelper<Uppercase<Key>, Value>
     : Spec extends keyof Entity & string
-      ? [Uppercase<Spec>, Entity[Spec] & joinable]
-      : never
+    ? [Uppercase<Spec>, Entity[Spec] & joinable]
+    : never
 
 type CompositeKeyStringBuilder<
     Entity,
@@ -77,26 +77,26 @@ type CompositeKeyStringBuilder<
     AllAcc extends string = never,
 > = Spec extends [infer Head, ...infer Tail]
     ? ExtractPair<Entity, Head> extends [
-          infer Key extends joinable,
-          infer Value extends joinable,
-      ]
-        ? CompositeKeyStringBuilder<
-              Entity,
-              Tail,
-              Separator,
-              KeepIntermediate,
-              Acc extends ''
-                  ? [Key] extends [never]
-                      ? `${Value}`
-                      : `${Key}${Separator}${Value}`
-                  : [Key] extends [never]
-                    ? `${Acc}${Separator}${Value}`
-                    : `${Acc}${Separator}${Key}${Separator}${Value}`,
-              KeepIntermediate extends true
-                  ? AllAcc | (Acc extends '' ? never : Acc)
-                  : never
-          >
+        infer Key extends joinable,
+        infer Value extends joinable,
+    ]
+    ? CompositeKeyStringBuilder<
+        Entity,
+        Tail,
+        Separator,
+        KeepIntermediate,
+        Acc extends ''
+        ? [Key] extends [never]
+        ? `${Value}`
+        : `${Key}${Separator}${Value}`
+        : [Key] extends [never]
+        ? `${Acc}${Separator}${Value}`
+        : `${Acc}${Separator}${Key}${Separator}${Value}`,
+        KeepIntermediate extends true
+        ? AllAcc | (Acc extends '' ? never : Acc)
         : never
+    >
+    : never
     : AllAcc | Acc
 
 type CompositeKeyBuilderImpl<
@@ -107,15 +107,15 @@ type CompositeKeyBuilderImpl<
     isPartial extends boolean = false,
 > = Entity extends unknown
     ? CompositeKeyStringBuilder<
-          Entity,
-          [Deep] extends [never]
-              ? Spec
-              : number extends Deep
-                ? Spec
-                : SliceFromStart<Spec, Deep>,
-          Separator,
-          boolean extends isPartial ? false : isPartial
-      >
+        Entity,
+        [Deep] extends [never]
+        ? Spec
+        : number extends Deep
+        ? Spec
+        : SliceFromStart<Spec, Deep>,
+        Separator,
+        boolean extends isPartial ? false : isPartial
+    >
     : never
 
 export type CompositeKeyBuilder<
@@ -138,10 +138,23 @@ type InputSpecShape =
     ([PropertyKey, (key: any) => unknown, ...unknown[]] | PropertyKey)[]
 export type TransformShape =
     | {
-          tag?: string
-          value: joinable
-      }
+        tag?: string
+        value: joinable
+    }
     | joinable
+
+type ComputeTableKeyType<
+    Entity,
+    Spec,
+    Separator extends string,
+    NullAs extends never | undefined = never,
+> = Spec extends InputSpecShape
+    ? CompositeKeyBuilderImpl<Entity, Spec, Separator, number, false>
+    : Spec extends keyof Entity
+    ? Replace<Entity[Spec], null, undefined>
+    : Spec extends null
+    ? NullAs
+    : never
 
 type TableEntryImpl<
     Entity,
@@ -149,17 +162,17 @@ type TableEntryImpl<
     Separator extends string = '#',
 > = Entity extends unknown
     ? {
-          [Key in keyof Schema]: Schema[Key] extends DiscriminatedSchemaShape
-              ? ProcessKey<
-                    Entity,
-                    ValueOf<
-                        Schema[Key]['spec'],
-                        ValueOf<Entity, Schema[Key]['discriminator']>
-                    >,
-                    Separator
-                >
-              : ProcessKey<Entity, Schema[Key], Separator>
-      } & Entity
+        [Key in keyof Schema]: Schema[Key] extends DiscriminatedSchemaShape
+        ? ComputeTableKeyType<
+            Entity,
+            ValueOf<
+                Schema[Key]['spec'],
+                ValueOf<Entity, Schema[Key]['discriminator']>
+            >,
+            Separator
+        >
+        : ComputeTableKeyType<Entity, Schema[Key], Separator>
+    } & Entity
     : never
 
 export type TableEntry<
@@ -170,14 +183,14 @@ export type TableEntry<
 
 type InputSpec<E> = {
     [key in keyof E]:
-        | (undefined extends E[key]
-              ? [
-                    key,
-                    (key: Exclude<E[key], undefined>) => TransformShape,
-                    Exclude<E[key], undefined>,
-                ]
-              : [key, (key: Exclude<E[key], undefined>) => TransformShape])
-        | (undefined extends E[key] ? never : null extends E[key] ? never : key)
+    | (undefined extends E[key]
+        ? [
+            key,
+            (key: Exclude<E[key], undefined>) => TransformShape,
+            Exclude<E[key], undefined>,
+        ]
+        : [key, (key: Exclude<E[key], undefined>) => TransformShape])
+    | (undefined extends E[key] ? never : null extends E[key] ? never : key)
 }[keyof E]
 
 type extractHeadOrPass<T> = T extends readonly unknown[] ? T[0] : T
@@ -191,20 +204,20 @@ type FullKeySpecSimpleShape = InputSpecShape | string | null
 
 type DiscriminatedSchema<Entity, E> = {
     [key in keyof E]: E[key] extends PropertyKey
-        ? {
-              discriminator: key
-              spec: {
-                  [val in E[key]]: FullKeySpecSimple<
-                      Extract<
-                          Entity,
-                          {
-                              [k in key]: val
-                          }
-                      >
-                  >
-              }
-          }
-        : never
+    ? {
+        discriminator: key
+        spec: {
+            [val in E[key]]: FullKeySpecSimple<
+                Extract<
+                    Entity,
+                    {
+                        [k in key]: val
+                    }
+                >
+            >
+        }
+    }
+    : never
 }[keyof E]
 
 type FullKeySpec<Entity> =
@@ -218,7 +231,7 @@ const chainableNoOpProxy: unknown = new Proxy(() => chainableNoOpProxy, {
 })
 
 const createPathProxy = <T>(path = ''): T => {
-    return new Proxy(() => {}, {
+    return new Proxy(() => { }, {
         get: (_target, prop) => {
             if (typeof prop === 'string') {
                 if (prop === 'toString') {
@@ -229,8 +242,8 @@ const createPathProxy = <T>(path = ''): T => {
                     path === ''
                         ? prop
                         : !Number.isNaN(Number.parseInt(prop))
-                          ? `${path}[${prop}]`
-                          : `${path}.${prop}`,
+                            ? `${path}[${prop}]`
+                            : `${path}.${prop}`,
                 )
             }
         },
@@ -239,177 +252,177 @@ const createPathProxy = <T>(path = ''): T => {
 
 const key =
     <const Entity>() =>
-    <
-        const Schema extends Record<
-            string,
-            | InputSpec<MergeIntersectionObject<Entity>>[]
-            | keyof Entity
-            | {
-                  discriminator: keyof Entity
-                  spec: {
-                      [val in string]:
-                          | InputSpec<MergeIntersectionObject<Entity>>[]
-                          | keyof Entity
-                  }
-              }
-        >,
-        Separator extends string = '#',
-    >(
-        schema: Schema,
-        separator: Separator = '#' as Separator,
-    ) =>
-    <
-        const Key extends keyof Schema,
-        const Config extends {
-            depth?: number
-            allowPartial?: boolean
-            enforceBoundary?: boolean
-        },
-        const Attributes extends Partial<Entity>,
-    >(
-        key: Key,
-        attributes: Attributes,
-        config?: Config,
-    ): string | undefined => {
-        const case_ = schema[key]
-
-        if (case_ === undefined) {
-            throw new Error(`Key ${key.toString()} not found in schema`)
-        }
-        let structure: InputSpec<MergeIntersectionObject<Entity>>[]
-
-        if (Array.isArray(case_)) {
-            structure = case_
-        } else if (typeof case_ === 'object') {
-            const discriminator =
-                attributes[case_.discriminator as keyof Attributes]
-            if (discriminator === undefined) {
-                throw new Error(
-                    `Discriminator ${case_.discriminator.toString()} not found in ${JSON.stringify(attributes)}`,
-                )
-            }
-            const val = case_.spec[discriminator as keyof typeof case_.spec]
-            if (val === undefined) {
-                throw new Error(
-                    `Discriminator value ${discriminator?.toString()} not found in ${JSON.stringify(attributes)}`,
-                )
-            }
-            if (val === null) {
-                return undefined
-            }
-
-            if (!Array.isArray(val)) {
-                return attributes[val as keyof Attributes] as never
-            }
-
-            structure = val
-        } else {
-            const value = attributes[case_ as keyof Attributes]
-            if (value == null) return undefined as never
-
-            return value as never
-        }
-
-        const fullLength = structure.length
-
-        if (config?.depth !== undefined) {
-            structure = structure.slice(0, config.depth) as never
-        }
-        const composite: joinable[] = []
-
-        for (const keySpec of structure) {
-            const [key, transform, Default] = Array.isArray(keySpec)
-                ? keySpec
-                : [keySpec]
-
-            const value = attributes[key as keyof Attributes] ?? Default
-
-            if (transform && value !== undefined) {
-                const transformed = transform(value as never)
-                if (typeof transformed === 'object' && transformed !== null) {
-                    if (transformed.tag !== undefined)
-                        composite.push(transformed.tag)
-                    composite.push(transformed.value)
-                } else {
-                    composite.push(key.toString().toUpperCase())
-                    composite.push(transformed)
+        <
+            const Schema extends Record<
+                string,
+                | InputSpec<MergeIntersectionObject<Entity>>[]
+                | keyof Entity
+                | {
+                    discriminator: keyof Entity
+                    spec: {
+                        [val in string]:
+                        | InputSpec<MergeIntersectionObject<Entity>>[]
+                        | keyof Entity
+                    }
                 }
-            } else if (value !== undefined && value !== null && value !== '') {
-                composite.push(key.toString().toUpperCase())
-                composite.push(value as joinable)
-            } else if (config?.allowPartial) {
-                break
-            } else {
-                throw new Error(
-                    `buildCompositeKey: Attribute ${key.toString()} not found in ${JSON.stringify(attributes)}`,
-                )
+            >,
+            Separator extends string = '#',
+        >(
+            schema: Schema,
+            separator: Separator = '#' as Separator,
+        ) =>
+            <
+                const Key extends keyof Schema,
+                const Config extends {
+                    depth?: number
+                    allowPartial?: boolean
+                    enforceBoundary?: boolean
+                },
+                const Attributes extends Partial<Entity>,
+            >(
+                key: Key,
+                attributes: Attributes,
+                config?: Config,
+            ): string | undefined => {
+                const case_ = schema[key]
+
+                if (case_ === undefined) {
+                    throw new Error(`Key ${key.toString()} not found in schema`)
+                }
+                let structure: InputSpec<MergeIntersectionObject<Entity>>[]
+
+                if (Array.isArray(case_)) {
+                    structure = case_
+                } else if (typeof case_ === 'object') {
+                    const discriminator =
+                        attributes[case_.discriminator as keyof Attributes]
+                    if (discriminator === undefined) {
+                        throw new Error(
+                            `Discriminator ${case_.discriminator.toString()} not found in ${JSON.stringify(attributes)}`,
+                        )
+                    }
+                    const val = case_.spec[discriminator as keyof typeof case_.spec]
+                    if (val === undefined) {
+                        throw new Error(
+                            `Discriminator value ${discriminator?.toString()} not found in ${JSON.stringify(attributes)}`,
+                        )
+                    }
+                    if (val === null) {
+                        return undefined
+                    }
+
+                    if (!Array.isArray(val)) {
+                        return attributes[val as keyof Attributes] as never
+                    }
+
+                    structure = val
+                } else {
+                    const value = attributes[case_ as keyof Attributes]
+                    if (value == null) return undefined as never
+
+                    return value as never
+                }
+
+                const fullLength = structure.length
+
+                if (config?.depth !== undefined) {
+                    structure = structure.slice(0, config.depth) as never
+                }
+                const composite: joinable[] = []
+
+                for (const keySpec of structure) {
+                    const [key, transform, Default] = Array.isArray(keySpec)
+                        ? keySpec
+                        : [keySpec]
+
+                    const value = attributes[key as keyof Attributes] ?? Default
+
+                    if (transform && value !== undefined) {
+                        const transformed = transform(value as never)
+                        if (typeof transformed === 'object' && transformed !== null) {
+                            if (transformed.tag !== undefined)
+                                composite.push(transformed.tag)
+                            composite.push(transformed.value)
+                        } else {
+                            composite.push(key.toString().toUpperCase())
+                            composite.push(transformed)
+                        }
+                    } else if (value !== undefined && value !== null && value !== '') {
+                        composite.push(key.toString().toUpperCase())
+                        composite.push(value as joinable)
+                    } else if (config?.allowPartial) {
+                        break
+                    } else {
+                        throw new Error(
+                            `buildCompositeKey: Attribute ${key.toString()} not found in ${JSON.stringify(attributes)}`,
+                        )
+                    }
+                }
+
+                if (config?.enforceBoundary && fullLength * 2 > composite.length) {
+                    composite.push('')
+                }
+
+                return composite.join(separator) as never
             }
-        }
-
-        if (config?.enforceBoundary && fullLength * 2 > composite.length) {
-            composite.push('')
-        }
-
-        return composite.join(separator) as never
-    }
 
 const toEntry =
     <const Entity extends Record<string, unknown>>() =>
-    <
-        const Schema extends Record<
-            string,
-            | InputSpec<MergeIntersectionObject<Entity>>[]
-            | keyof Entity
-            | {
-                  discriminator: keyof Entity
-                  spec: {
-                      [val in string]:
-                          | InputSpec<MergeIntersectionObject<Entity>>[]
-                          | keyof Entity
-                  }
-              }
-        >,
-        Separator extends string = '#',
-    >(
-        schema: Schema,
-        separator: Separator = '#' as Separator,
-    ) =>
-    <const ExactEntity extends Entity>(
-        item: ExactEntity,
-    ): ExactEntity extends infer E extends Entity
-        ? TableEntryImpl<E, Schema, Separator>
-        : never => {
-        const entry = { ...item }
+        <
+            const Schema extends Record<
+                string,
+                | InputSpec<MergeIntersectionObject<Entity>>[]
+                | keyof Entity
+                | {
+                    discriminator: keyof Entity
+                    spec: {
+                        [val in string]:
+                        | InputSpec<MergeIntersectionObject<Entity>>[]
+                        | keyof Entity
+                    }
+                }
+            >,
+            Separator extends string = '#',
+        >(
+            schema: Schema,
+            separator: Separator = '#' as Separator,
+        ) =>
+            <const ExactEntity extends Entity>(
+                item: ExactEntity,
+            ): ExactEntity extends infer E extends Entity
+                ? TableEntryImpl<E, Schema, Separator>
+                : never => {
+                const entry = { ...item }
 
-        for (const key_ in schema) {
-            const val = key<Entity>()(schema, separator)(key_, item)
-            if (val !== undefined) {
-                entry[key_] = val satisfies string as never
+                for (const key_ in schema) {
+                    const val = key<Entity>()(schema, separator)(key_, item)
+                    if (val !== undefined) {
+                        entry[key_] = val satisfies string as never
+                    }
+                }
+                // console.log({ entry })
+                return entry as never
             }
-        }
-        // console.log({ entry })
-        return entry as never
-    }
 
 const fromEntry =
     <const Entity extends Record<string, unknown>>() =>
-    <
-        const Schema extends Record<string, FullKeySpecShape>,
-        Separator extends string = '#',
-    >(
-        schema: Schema,
-    ) =>
-    <const Entry extends TableEntryImpl<Entity, Schema, Separator>>(
-        entry: Entry,
-    ): DistributiveOmit<Entry, keyof Schema> => {
-        const item = { ...entry }
+        <
+            const Schema extends Record<string, FullKeySpecShape>,
+            Separator extends string = '#',
+        >(
+            schema: Schema,
+        ) =>
+            <const Entry extends TableEntryImpl<Entity, Schema, Separator>>(
+                entry: Entry,
+            ): DistributiveOmit<Entry, keyof Schema> => {
+                const item = { ...entry }
 
-        for (const key_ in schema) {
-            delete item[key_]
-        }
-        // console.log({ item })
-        return item as never
-    }
+                for (const key_ in schema) {
+                    delete item[key_]
+                }
+                // console.log({ item })
+                return item as never
+            }
 
 type ProcessSpecType<
     Entity,
@@ -418,14 +431,14 @@ type ProcessSpecType<
 > = Spec extends string
     ? DistributivePick<Entity, Spec>
     : Spec extends InputSpecShape
-      ? CompositeKeyParamsImpl<
-            Entity,
-            Spec,
-            Config['allowPartial'] extends true
-                ? 1
-                : Extract<Config['depth'], number>
-        >
-      : never
+    ? CompositeKeyParamsImpl<
+        Entity,
+        Spec,
+        Config['allowPartial'] extends true
+        ? 1
+        : Extract<Config['depth'], number>
+    >
+    : never
 
 // Cache commonly used conditional types
 type SpecConfig<Spec> = Spec extends string ? never : SpecConfigShape
@@ -467,16 +480,16 @@ type OptimizedAttributes<
     Config extends SpecConfigShape,
 > = Spec extends DiscriminatedSchemaShape
     ? {
-          [K in Spec['discriminator']]: {
-              [V in keyof Spec['spec']]: ProcessVariant<
-                  Entity,
-                  K,
-                  V,
-                  Spec,
-                  Config
-              >
-          }[keyof Spec['spec']]
-      }[Spec['discriminator']]
+        [K in Spec['discriminator']]: {
+            [V in keyof Spec['spec']]: ProcessVariant<
+                Entity,
+                K,
+                V,
+                Spec,
+                Config
+            >
+        }[keyof Spec['spec']]
+    }[Spec['discriminator']]
     : ProcessSpecType<Entity, Spec, Config>
 
 type ProcessKey<
@@ -489,18 +502,18 @@ type ProcessKey<
 > = [Entity] extends [never]
     ? never
     : Spec extends keyof Entity
-      ? Replace<ValueOf<Attributes>, null, undefined>
-      : Spec extends InputSpecShape
-        ? CompositeKeyBuilderImpl<
-              Entity,
-              Spec,
-              Separator,
-              Exclude<Config['depth'], undefined>,
-              Exclude<Config['allowPartial'], undefined>
-          >
-        : Spec extends null
-          ? NullAs
-          : never
+    ? Replace<ValueOf<Attributes>, null, undefined>
+    : Spec extends InputSpecShape
+    ? CompositeKeyBuilderImpl<
+        Entity,
+        Spec,
+        Separator,
+        Exclude<Config['depth'], undefined>,
+        Exclude<Config['allowPartial'], undefined>
+    >
+    : Spec extends null
+    ? NullAs
+    : never
 
 type OptimizedBuildedKey<
     Entity,
@@ -510,15 +523,15 @@ type OptimizedBuildedKey<
     Attributes,
 > = Entity extends unknown
     ? Spec extends DiscriminatedSchemaShape
-        ? ProcessKey<
-              Entity,
-              ValueOf<Spec['spec'], ValueOf<Entity, Spec['discriminator']>>,
-              Separator,
-              undefined,
-              Config,
-              Attributes
-          >
-        : ProcessKey<Entity, Spec, Separator, undefined, Config, Attributes>
+    ? ProcessKey<
+        Entity,
+        ValueOf<Spec['spec'], ValueOf<Entity, Spec['discriminator']>>,
+        Separator,
+        undefined,
+        Config,
+        Attributes
+    >
+    : ProcessKey<Entity, Spec, Separator, undefined, Config, Attributes>
     : never
 
 type TableEntryDefinition<Entity, Schema, Separator extends string> = {
@@ -534,12 +547,12 @@ type TableEntryDefinition<Entity, Schema, Separator extends string> = {
         const Attributes extends OptimizedAttributes<Entity, Spec, Config_>,
         Spec = Schema[Key],
         Config_ extends SpecConfigShape = [SpecConfigShape] extends [Config] // exclude undefined param
-            ? {
-                  depth?: undefined
-                  allowPartial?: undefined
-                  enforceBoundary?: boolean
-              }
-            : Config,
+        ? {
+            depth?: undefined
+            allowPartial?: undefined
+            enforceBoundary?: boolean
+        }
+        : Config,
     >(
         key: Key,
         attributes: Attributes,
@@ -551,18 +564,18 @@ type TableEntryDefinition<Entity, Schema, Separator extends string> = {
 
 export const tableEntry =
     <const Entity extends Record<string, unknown>>() =>
-    <
-        const Schema extends Record<string, FullKeySpec<Entity>>,
-        Separator extends string = '#',
-    >(
-        schema: Schema,
-        separator: Separator = '#' as Separator,
-    ): TableEntryDefinition<Entity, Schema, Separator> => {
-        return {
-            toEntry: toEntry()(schema as never, separator) as never,
-            fromEntry: fromEntry()(schema as never) as never,
-            key: key()(schema as never, separator) as never,
-            infer: chainableNoOpProxy as never,
-            path: () => createPathProxy() as never,
+        <
+            const Schema extends Record<string, FullKeySpec<Entity>>,
+            Separator extends string = '#',
+        >(
+            schema: Schema,
+            separator: Separator = '#' as Separator,
+        ): TableEntryDefinition<Entity, Schema, Separator> => {
+            return {
+                toEntry: toEntry()(schema as never, separator) as never,
+                fromEntry: fromEntry()(schema as never) as never,
+                key: key()(schema as never, separator) as never,
+                infer: chainableNoOpProxy as never,
+                path: () => createPathProxy() as never,
+            }
         }
-    }

--- a/src/Rotorise.ts
+++ b/src/Rotorise.ts
@@ -239,6 +239,13 @@ type FullKeySpec<Entity> =
 
 type FullKeySpecShape = FullKeySpecSimpleShape | DiscriminatedSchemaShape
 
+export class RotoriseError extends Error {
+    constructor(message: string) {
+        super(message)
+        this.name = 'RotoriseError'
+    }
+}
+
 const chainableNoOpProxy: unknown = new Proxy(() => chainableNoOpProxy, {
     get: () => chainableNoOpProxy,
 })
@@ -300,7 +307,7 @@ const key =
         const case_ = schema[key]
 
         if (case_ === undefined) {
-            throw new Error(`Key ${key.toString()} not found in schema`)
+            throw new RotoriseError(`Key ${key.toString()} not found in schema`)
         }
         let structure: InputSpec<MergeIntersectionObject<Entity>>[]
 
@@ -310,13 +317,13 @@ const key =
             const discriminator =
                 attributes[case_.discriminator as keyof Attributes]
             if (discriminator === undefined) {
-                throw new Error(
+                throw new RotoriseError(
                     `Discriminator ${case_.discriminator.toString()} not found in ${JSON.stringify(attributes)}`,
                 )
             }
             const val = case_.spec[discriminator as keyof typeof case_.spec]
             if (val === undefined) {
-                throw new Error(
+                throw new RotoriseError(
                     `Discriminator value ${discriminator?.toString()} not found in ${JSON.stringify(attributes)}`,
                 )
             }
@@ -366,7 +373,7 @@ const key =
             } else if (config?.allowPartial) {
                 break
             } else {
-                throw new Error(
+                throw new RotoriseError(
                     `buildCompositeKey: Attribute ${key.toString()} not found in ${JSON.stringify(attributes)}`,
                 )
             }
@@ -630,6 +637,8 @@ type TableEntryDefinition<Entity, Schema, Separator extends string> = {
  * @template Entity The base entity type that this table represents.
  * @returns A builder function that accepts the schema and an optional separator.
  *
+ * Note: the double-call `<Entity>()(schema)` is required for partial type parameter inference.
+ *
  * @example
  * const userTable = tableEntry<User>()({
  *   PK: ["orgId", "id"],
@@ -646,7 +655,7 @@ export const tableEntry =
         separator: Separator = '#' as Separator,
     ): TableEntryDefinition<Entity, Schema, Separator> => {
         if (separator === '') {
-            throw new Error('Separator must not be an empty string')
+            throw new RotoriseError('Separator must not be an empty string')
         }
         return {
             toEntry: toEntry()(schema as never, separator) as never,

--- a/src/Rotorise.ts
+++ b/src/Rotorise.ts
@@ -678,15 +678,18 @@ export const tableEntry =
         Separator extends string = '#',
     >(
         schema: Schema,
-        separator: Separator = '#' as Separator,
+        ...[separator]: [Separator] extends ['']
+            ? [ErrorMessage<'Separator must not be an empty string'>]
+            : [separator?: Separator]
     ): TableEntryDefinition<Entity, Schema, Separator> => {
-        if (separator === '') {
+        const sep = separator ?? ('#' as Separator)
+        if (sep === '' || typeof sep !== 'string') {
             throw new RotoriseError('Separator must not be an empty string')
         }
         return {
-            toEntry: toEntry()(schema as never, separator) as never,
+            toEntry: toEntry()(schema as never, sep) as never,
             fromEntry: fromEntry()(schema as never) as never,
-            key: key()(schema as never, separator) as never,
+            key: key()(schema as never, sep) as never,
             infer: chainableNoOpProxy as never,
             path: () => createPathProxy() as never,
         }

--- a/src/Rotorise.ts
+++ b/src/Rotorise.ts
@@ -246,6 +246,11 @@ export class RotoriseError extends Error {
     }
 }
 
+// Runtime implementation uses `as never` casts because the generic types are
+// too complex for TS to verify at the value level. Type correctness is enforced
+// by the type-level types (CompositeKeyStringBuilder, TableEntryImpl, etc.) and
+// validated by the attest-based test suite.
+
 const chainableNoOpProxy: unknown = new Proxy(() => chainableNoOpProxy, {
     get: () => chainableNoOpProxy,
 })
@@ -346,7 +351,7 @@ const key =
         const fullLength = structure.length
 
         if (config?.depth !== undefined) {
-            structure = structure.slice(0, config.depth) as never
+            structure = structure.slice(0, config.depth) as typeof structure
         }
         const composite: joinable[] = []
 

--- a/src/Rotorise.ts
+++ b/src/Rotorise.ts
@@ -8,9 +8,7 @@ import type {
     SliceFromStart,
     ValueOf,
     show,
-    conform,
     ErrorMessage,
-    satisfy,
 } from './utils'
 
 type PartialPick<T, K extends keyof T> = { [P in K]?: T[P] }
@@ -88,7 +86,7 @@ type ExtractHelper<Key, Value> = Value extends object
 
 type ExtractPair<Entity, Spec> = Spec extends [
     infer Key extends string,
-    // biome-ignore lint/suspicious/noExplicitAny: <explanation>
+    // biome-ignore lint/suspicious/noExplicitAny: required for generic transform inference
     (...key: any[]) => infer Value,
     ...unknown[],
 ]
@@ -136,8 +134,9 @@ type DiscriminatedSchemaShape = {
 }
 
 type InputSpecShape =
-    // biome-ignore lint/suspicious/noExplicitAny: ggg
+    // biome-ignore lint/suspicious/noExplicitAny: key type is erased at runtime, any is needed for structural matching
     ([PropertyKey, (key: any) => unknown, ...unknown[]] | PropertyKey)[]
+
 export type TransformShape =
     | {
           tag?: string
@@ -373,6 +372,8 @@ const key =
             }
         }
 
+        // Each spec element produces 2 segments (KEY, value). If fewer segments
+        // were emitted than expected (partial key), append a trailing separator.
         if (config?.enforceBoundary && fullLength * 2 > composite.length) {
             composite.push('')
         }
@@ -407,14 +408,14 @@ const toEntry =
         ? TableEntryImpl<E, Schema, Separator>
         : never => {
         const entry = { ...item }
+        const buildKey = key<Entity>()(schema, separator)
 
         for (const key_ in schema) {
-            const val = key<Entity>()(schema, separator)(key_, item)
+            const val = buildKey(key_, item)
             if (val !== undefined) {
                 entry[key_] = val satisfies string as never
             }
         }
-        // console.log({ entry })
         return entry as never
     }
 
@@ -434,7 +435,6 @@ const fromEntry =
         for (const key_ in schema) {
             delete item[key_]
         }
-        // console.log({ item })
         return item as never
     }
 
@@ -465,7 +465,6 @@ type SpecConfigShape = {
     enforceBoundary?: boolean
 }
 
-// Pre-compute discriminated variant types
 // Pre-compute discriminated variant types
 type ExtractVariant<Entity, K extends PropertyKey, V extends PropertyKey> = [
     Entity,
@@ -535,7 +534,7 @@ type ProcessKey<
           ? NullAs
           : ErrorMessage<'Invalid Spec'>
 
-type OptimizedBuildedKey<
+type OptimizedBuiltKey<
     Entity,
     Spec,
     Separator extends string,
@@ -607,7 +606,7 @@ type TableEntryDefinition<Entity, Schema, Separator extends string> = {
         key: Key,
         attributes: Attributes,
         config?: Config,
-    ) => OptimizedBuildedKey<Attributes, Spec, Separator, Config_, Attributes>
+    ) => OptimizedBuiltKey<Attributes, Spec, Separator, Config_, Attributes>
 
     /**
      * A zero-runtime inference helper. Use this with `typeof` to get the
@@ -646,6 +645,9 @@ export const tableEntry =
         schema: Schema,
         separator: Separator = '#' as Separator,
     ): TableEntryDefinition<Entity, Schema, Separator> => {
+        if (separator === '') {
+            throw new Error('Separator must not be an empty string')
+        }
         return {
             toEntry: toEntry()(schema as never, separator) as never,
             fromEntry: fromEntry()(schema as never) as never,

--- a/src/Rotorise.ts
+++ b/src/Rotorise.ts
@@ -13,7 +13,7 @@ import type {
 
 // When a spec item has a transform function, use the transform's parameter type
 // instead of the entity's property type. This allows callers to pass only the
-// fields the transform actually needs (e.g. Pick<Device, 'userId'> instead of Device).
+// fields the transform actually needs (e.g. Pick<Obj, 'id'> instead of Obj).
 type TransformOverride<
     Spec extends InputSpecShape,
     K,
@@ -22,7 +22,7 @@ type TransformOverride<
 > = [Matched] extends [never]
     ? Fallback
     : // Contravariant inference: when the same key appears multiple times with
-      // different transforms (e.g. Pick<Device,'userId'> and Pick<Device,'deviceId'>),
+      // different transforms (e.g. Pick<Obj,'id'> and Pick<Obj,'name'>),
       // this intersects the parameter types rather than unioning them.
       (
           Matched extends [any, (x: infer P) => any, ...any[]]

--- a/src/Rotorise.ts
+++ b/src/Rotorise.ts
@@ -11,7 +11,26 @@ import type {
     ErrorMessage,
 } from './utils'
 
-type PartialPick<T, K extends keyof T> = { [P in K]?: T[P] }
+// When a spec item has a transform function, use the transform's parameter type
+// instead of the entity's property type. This allows callers to pass only the
+// fields the transform actually needs (e.g. Pick<Device, 'userId'> instead of Device).
+type TransformOverride<
+    Spec extends InputSpecShape,
+    K,
+    Fallback,
+    Matched = Extract<Spec[number], [K, (...args: any[]) => any, ...any[]]>,
+> = [Matched] extends [never]
+    ? Fallback
+    : // Contravariant inference: when the same key appears multiple times with
+      // different transforms (e.g. Pick<Device,'userId'> and Pick<Device,'deviceId'>),
+      // this intersects the parameter types rather than unioning them.
+      (
+          Matched extends [any, (x: infer P) => any, ...any[]]
+              ? (x: P) => void
+              : never
+      ) extends (x: infer I) => void
+      ? I
+      : Fallback
 
 export type CompositeKeyParamsImpl<
     Entity,
@@ -19,20 +38,22 @@ export type CompositeKeyParamsImpl<
     skip extends number = 1,
 > = Entity extends unknown
     ? show<
-          Pick<
-              Entity,
-              extractHeadOrPass<
+          {
+              [K in extractHeadOrPass<
                   SliceFromStart<
                       InputSpec,
                       number extends skip ? 1 : skip
                   >[number]
               > &
-                  keyof Entity
-          > &
-              PartialPick<
-                  Entity,
-                  extractHeadOrPass<InputSpec[number]> & keyof Entity
+                  keyof Entity]: TransformOverride<
+                  InputSpec,
+                  K,
+                  Entity[K]
               >
+          } & {
+              [K in extractHeadOrPass<InputSpec[number]> &
+                  keyof Entity]?: TransformOverride<InputSpec, K, Entity[K]>
+          }
       >
     : never
 

--- a/src/utils.d.ts
+++ b/src/utils.d.ts
@@ -9,29 +9,10 @@ export type IsEqual<T, U> = (<G>() => G extends T ? 1 : 2) extends <
 
 export type ArrayElement<T> = T extends readonly unknown[] ? T[0] : never
 
-export type ExactObject<ParameterType, InputType> = {
-    [Key in keyof ParameterType]: Exact<
-        ParameterType[Key],
-        Key extends keyof InputType ? InputType[Key] : never
-    >
-} & Record<Exclude<keyof InputType, KeysOfUnion<ParameterType>>, never>
-
-export type Exact<ParameterType, InputType> = IsEqual<
-    ParameterType,
-    InputType
-> extends true
-    ? ParameterType
-    : // Convert union of array to array of union: A[] & B[] => (A & B)[]
-      ParameterType extends unknown[]
-      ? Array<Exact<ArrayElement<ParameterType>, ArrayElement<InputType>>>
-      : // In TypeScript, Array is a subtype of ReadonlyArray, so always test Array before ReadonlyArray.
-        ParameterType extends readonly unknown[]
-        ? ReadonlyArray<
-              Exact<ArrayElement<ParameterType>, ArrayElement<InputType>>
-          >
-        : ParameterType extends object
-          ? ExactObject<ParameterType, InputType>
-          : ParameterType
+// Lighter Exact implementation
+export type Exact<Shape, Candidate> = Candidate & {
+    [K in keyof Candidate]: K extends keyof Shape ? Candidate[K] : never
+}
 
 export type ValueOf<
     ObjectType,

--- a/src/utils.d.ts
+++ b/src/utils.d.ts
@@ -58,13 +58,19 @@ export type SliceFromStart<
     T,
     End extends number,
     Acc extends unknown[] = [],
-> = T extends unknown[]
-    ? Acc['length'] extends End
-        ? Acc
-        : T extends [infer Head, ...infer Tail]
-          ? SliceFromStart<Tail, End, [...Acc, Head]>
-          : Acc
-    : never
+> = End extends 0
+    ? []
+    : End extends 1
+      ? T extends [infer Head, ...unknown[]]
+          ? [Head]
+          : []
+      : T extends unknown[]
+        ? Acc['length'] extends End
+            ? Acc
+            : T extends [infer Head, ...infer Tail]
+              ? SliceFromStart<Tail, End, [...Acc, Head]>
+              : Acc
+        : never
 
 export type Slices<
     Rest extends unknown[],

--- a/src/utils.d.ts
+++ b/src/utils.d.ts
@@ -19,11 +19,18 @@ export type ValueOf<
     ValueType = keyof ObjectType,
 > = ValueType extends keyof ObjectType ? ObjectType[ValueType] : never
 
-export type evaluateUnion<T> = T extends unknown
+/**
+ * Force an operation like `{ a: 0 } & { b: 1 }` to be computed so that it displays `{ a: 0; b: 1 }`.
+ * This version is distributive, meaning it will preserve union types while flattening each member.
+ */
+export type show<T> = T extends unknown
     ? { [K in keyof T]: T[K] } & unknown
     : never
 
+/** @deprecated use "show" instead */
 export type evaluate<T> = { [K in keyof T]: T[K] } & unknown
+
+export type conform<T, Base> = T extends Base ? T : Base
 
 export type DistributivePick<T, K> = T extends unknown
     ? K extends keyof T
@@ -81,3 +88,45 @@ export type MergeIntersectionObject<T, Keys = keyof T> = {
 export type NonEmptyArray<T> = [T, ...T[]]
 
 export type Replace<T, U, V> = T extends U ? V : T
+
+/**
+ * Represents a type-level error message. Used to provide helpful feedback in the IDE.
+ */
+export declare const errorMessage: unique symbol
+export type ErrorMessage<T extends string> = {
+    readonly [errorMessage]: T
+}
+
+/**
+ * Standard Ark-style Higher-Kinded Type (HKT) base class.
+ */
+export declare const hkt: unique symbol
+export abstract class Hkt<F = unknown> {
+    declare readonly [hkt]: F
+    abstract body: unknown
+}
+
+/**
+ * Applies an HKT to an argument.
+ */
+export type apply<H extends Hkt, Arg> = (H & {
+    readonly [0]: Arg
+})['body']
+
+/**
+ * Ensures that a type `T` satisfies a base constraint `Base`.
+ */
+export type satisfy<Base, T extends Base> = T
+
+/**
+ * Utility for creating branded types (nominal types).
+ */
+export declare const brand: unique symbol
+export type Brand<T, Id> = T & {
+    readonly [brand]: Id
+}
+
+/**
+ * Extracts the base type from a branded type.
+ */
+export type unbrand<T> = T extends Brand<infer Base, unknown> ? Base : T

--- a/src/utils.d.ts
+++ b/src/utils.d.ts
@@ -1,15 +1,6 @@
-export type KeysOfUnion<ObjectType> = ObjectType extends unknown
-    ? keyof ObjectType
-    : never
-export type IsEqual<T, U> = (<G>() => G extends T ? 1 : 2) extends <
-    G,
->() => G extends U ? 1 : 2
-    ? true
-    : false
-
-export type ArrayElement<T> = T extends readonly unknown[] ? T[0] : never
-
-// Lighter Exact implementation
+// Lighter Exact implementation — catches excess top-level properties only.
+// Does not recursively check nested objects/arrays. This is intentional:
+// DynamoDB entity shapes are flat at the key level.
 export type Exact<Shape, Candidate> = Candidate & {
     [K in keyof Candidate]: K extends keyof Shape ? Candidate[K] : never
 }
@@ -26,11 +17,6 @@ export type ValueOf<
 export type show<T> = T extends unknown
     ? { [K in keyof T]: T[K] } & unknown
     : never
-
-/** @deprecated use "show" instead */
-export type evaluate<T> = { [K in keyof T]: T[K] } & unknown
-
-export type conform<T, Base> = T extends Base ? T : Base
 
 export type DistributivePick<T, K> = T extends unknown
     ? K extends keyof T
@@ -60,30 +46,9 @@ export type SliceFromStart<
               : Acc
         : never
 
-export type Slices<
-    Rest extends unknown[],
-    MinLength extends number = 0,
-    Slice extends unknown[] = [],
-    Reached extends boolean = Slice['length'] extends MinLength ? true : false,
-    Acc = never,
-> = Rest extends [infer H, ...infer T]
-    ? [...Slice, H] extends infer X extends unknown[]
-        ? Slices<
-              T,
-              MinLength,
-              X,
-              X['length'] extends MinLength ? true : Reached,
-              Acc | (Reached extends true ? Slice : never)
-          >
-        : never
-    : Acc | (Reached extends true ? Slice : never)
-
 export type MergeIntersectionObject<T, Keys = keyof T> = {
     [K in Keys]: T[K]
 }
-// type t = MergeIntersectionObject<
-//     { a: 'a1'; b: 1n; extra: 'extra' } | { a: 'a2'; b: 2 }
-// >
 
 export type NonEmptyArray<T> = [T, ...T[]]
 
@@ -96,37 +61,3 @@ export declare const errorMessage: unique symbol
 export type ErrorMessage<T extends string> = {
     readonly [errorMessage]: T
 }
-
-/**
- * Standard Ark-style Higher-Kinded Type (HKT) base class.
- */
-export declare const hkt: unique symbol
-export abstract class Hkt<F = unknown> {
-    declare readonly [hkt]: F
-    abstract body: unknown
-}
-
-/**
- * Applies an HKT to an argument.
- */
-export type apply<H extends Hkt, Arg> = (H & {
-    readonly [0]: Arg
-})['body']
-
-/**
- * Ensures that a type `T` satisfies a base constraint `Base`.
- */
-export type satisfy<Base, T extends Base> = T
-
-/**
- * Utility for creating branded types (nominal types).
- */
-export declare const brand: unique symbol
-export type Brand<T, Id> = T & {
-    readonly [brand]: Id
-}
-
-/**
- * Extracts the base type from a branded type.
- */
-export type unbrand<T> = T extends Brand<infer Base, unknown> ? Base : T

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -8,5 +8,5 @@ export default defineConfig({
     clean: true,
     format: ['cjs', 'esm'],
     dts: true,
-
+    treeshake: true,
 })


### PR DESCRIPTION
## Summary

  - **Type-level performance** — fused and simplified core types (`CompositeKeyBuilder`, `SliceFromStart`, `ExtractHelper`, `ProcessVariant`, `TableEntryImpl`, `Exact`) to reduce
  TypeScript instantiation counts across the board
  - **`.key()` attribute narrowing** — transforms now narrow their parameter types (e.g. `Pick<A, 'w'>` instead of full `A`), with contravariant intersection when the same key appears
  in multiple spec positions
  - **Error diagnostics** — invalid schemas and specs surface `ErrorMessage<"...">` in the IDE instead of opaque `never`; empty separator is a compile-time error; all runtime errors
  throw `RotoriseError`
  - **Publish hygiene** — `files: ["dist"]`, `treeshake: true`, removed `@swc/jest`

  ## Breaking Changes

  - `Exact` only checks top-level excess properties (no deep recursion)
  - `.key()` attributes narrow to transform parameter types
  - Schema keys on `TableEntry` are `readonly`
  - Invalid schemas return `ErrorMessage<>` instead of `never`